### PR TITLE
sv: fix missing arguments failure.

### DIFF
--- a/sv
+++ b/sv
@@ -293,7 +293,7 @@ while [[ $# -gt 0 ]]; do
             ;;
     esac
 done
-set -- "${NEW_ARGS[@]}"
+set -- "${NEW_ARGS[@]:-}"
 
 # Parse fixed arguments
 case "${1:-}" in


### PR DESCRIPTION
Running `sv` without arguments doesn't print usage but instead an error as `NEW_ARGS` was never assigned. Correctly handle this so usage is displayed instead.