### PR TITLE
Fix zsh profile files for non-interactive use

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -2,8 +2,8 @@
 
 Thanks to the following users for improving SandVault:
 
-webcoyote (owner)
-AlessandroW
-MikeMcQuaid
-KingMob
-redLocomotive
+- webcoyote (owner)
+- AlessandroW
+- MikeMcQuaid
+- KingMob
+- redLocomotive

--- a/guest/home/.zlogin
+++ b/guest/home/.zlogin
@@ -1,5 +1,2 @@
-# Ensure current directory is readable
-[[ -r "$PWD" ]] || cd "$HOME"
-
 # Load user configuration
 [[ -f "$HOME/user/.zlogin" ]] && source "$HOME/user/.zlogin"

--- a/guest/home/.zlogout
+++ b/guest/home/.zlogout
@@ -1,5 +1,2 @@
-# Ensure current directory is readable
-[[ -r "$PWD" ]] || cd "$HOME"
-
 # Load user configuration
 [[ -f "$HOME/user/.zlogout" ]] && source "$HOME/user/.zlogout"

--- a/guest/home/.zprofile
+++ b/guest/home/.zprofile
@@ -1,5 +1,11 @@
 # Ensure current directory is readable
-[[ -r "$PWD" ]] || cd "$HOME"
+if [[ -r "${INITIAL_DIR:-}" ]]; then
+    cd "$INITIAL_DIR"
+elif [[ -r "${SHARED_WORKSPACE:-}" ]]; then
+    cd "$SHARED_WORKSPACE"
+elif [[ ! -r "$PWD" ]]; then
+    cd "$HOME"
+fi
 
 # Load user configuration
 [[ -f "$HOME/user/.zprofile" ]] && source "$HOME/user/.zprofile"

--- a/guest/home/.zshenv
+++ b/guest/home/.zshenv
@@ -1,5 +1,25 @@
-# Ensure current directory is readable
-[[ -r "$PWD" ]] || cd "$HOME"
+# Add Homebrew bin directories
+[[ -d "/opt/homebrew/bin" ]] && path=("/opt/homebrew/bin" $path)
+[[ -d "/opt/homebrew/sbin" ]] && path=("/opt/homebrew/sbin" $path)
+export PATH
+
+# Perform sandvault setup once per session
+if [[ -n "${SV_SESSION_ID:-}" ]]; then
+    sv_session_lock="/tmp/sandvault-configure-$SV_SESSION_ID"
+    if [[ ! -e "$sv_session_lock" ]]; then
+        : > "$sv_session_lock"
+
+        #echo "CONFIGURING"
+        "$HOME/configure"
+    fi
+fi
+
+# Add sandvault and user bin directories
+[[ -d "$HOME/bin" ]] && path=("$HOME/bin" $path)
+[[ -d "$HOME/.local/bin" ]] && path=("$HOME/.local/bin" $path)
+[[ -d "$HOME/user/bin" ]] && path=("$HOME/user/bin" $path)
+[[ -d "$HOME/user/.local/bin" ]] && path=("$HOME/user/.local/bin" $path)
+export PATH
 
 # Load user configuration
 [[ -f "$HOME/user/.zshenv" ]] && source "$HOME/user/.zshenv"

--- a/guest/home/.zshrc
+++ b/guest/home/.zshrc
@@ -1,35 +1,5 @@
-# Ensure current directory is readable
-[[ -r "$PWD" ]] || cd "$HOME"
-
-# Set custom prompt
-export PROMPT="%F{magenta}%n %F{blue}%~%f %# "
-
-# Setup PATH for Homebrew
-export PATH="/opt/homebrew/bin:/opt/homebrew/sbin:$PATH"
-
-# Perform sandvault setup
-"$HOME/configure"
-
-# sandvault bin directories
-export PATH="$HOME/bin:$HOME/.local/bin:$PATH"
-
-# user bin directories
-if [[ -d "$HOME/user/.local/bin" ]]; then
-    export PATH="$HOME/user/.local/bin:$PATH"
-fi
-if [[ -d "$HOME/user/bin" ]]; then
-    export PATH="$HOME/user/bin:$PATH"
-fi
-
 # Load user configuration
 [[ -f "$HOME/user/.zshrc" ]] && source "$HOME/user/.zshrc"
-
-# Set directory as requested
-if [[ -r "${INITIAL_DIR:-}" ]]; then
-    cd "$INITIAL_DIR"
-elif [[ -r "${SHARED_WORKSPACE:-}" ]]; then
-    cd "$SHARED_WORKSPACE"
-fi
 
 # Run specified application
 if [[ "${COMMAND:-}" != "" ]]; then

--- a/guest/home/configure
+++ b/guest/home/configure
@@ -3,7 +3,7 @@
 set -Eeuo pipefail
 trap 'echo "${BASH_SOURCE[0]}: line $LINENO: $BASH_COMMAND: exitcode $?"' ERR
 SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}" 2>/dev/null || echo "${BASH_SOURCE[0]}")")" && pwd)"
-
+cd "$SCRIPT_DIR"
 
 ###############################################################################
 # Functions

--- a/scripts/tests
+++ b/scripts/tests
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 # Test the sv CLI and sandbox security
 set -Eeuo pipefail
+START_TIME=$(date +%s.%N)
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SV="$SCRIPT_DIR/../sv"
@@ -161,6 +162,31 @@ assert_sandbox_contains "can run pwd" "pwd" "/"
 
 ###############################################################################
 echo ""
+echo "=== Initial Directory Tests ==="
+###############################################################################
+
+# Test that unreadable directory falls back to SHARED_WORKSPACE
+# Host user's home directory should not be readable by sandvault user
+((TESTS_RUN++)) || true
+output=$(cd "$HOST_HOME" && echo "pwd ; exit" | "$SV" s 2>&1)
+if [[ "$output" == *"$SHARED_WORKSPACE"* ]]; then
+    pass "unreadable directory falls back to SHARED_WORKSPACE"
+else
+    fail "unreadable directory falls back to SHARED_WORKSPACE" "$SHARED_WORKSPACE" "$output"
+fi
+
+# Test that readable directory is used as working directory
+# /Users is readable by all users
+((TESTS_RUN++)) || true
+output=$(cd /Users && echo "pwd ; exit" | "$SV" s 2>&1)
+if [[ "$output" == *"/Users"* ]]; then
+    pass "readable directory is used as working directory"
+else
+    fail "readable directory is used as working directory" "/Users" "$output"
+fi
+
+###############################################################################
+echo ""
 echo "=== Summary ==="
 ###############################################################################
 
@@ -171,3 +197,7 @@ echo -e "Failed: ${RED}$TESTS_FAILED${NC}"
 if [[ "$TESTS_FAILED" -gt 0 ]]; then
     exit 1
 fi
+
+END_TIME=$(date +%s.%N)
+ELAPSED_TIME=$(echo "$END_TIME - $START_TIME" | bc --mathlib | xargs printf "%.2f\n")
+echo -e "✅ Tests completed in $ELAPSED_TIME seconds!"

--- a/sv
+++ b/sv
@@ -694,6 +694,9 @@ if [[ ${#COMMAND_ARGS[@]} -gt 0 ]]; then
     printf -v COMMAND_ARGS_STR '%q ' "${COMMAND_ARGS[@]}"
 fi
 
+# Unique session id for this invocation (used by shell init scripts)
+SV_SESSION_ID="${SV_SESSION_ID:-$(/usr/bin/uuidgen)}"
+
 # TMPDIR: claude (and perhaps other AI agents) creates temporary directories in locations
 # that are shared, e.g. /tmp/claude and /private/tmp/claude, which doesn't work when there
 # are multiple users running the agent on the same computer. Try to correct for this by
@@ -722,6 +725,7 @@ if [[ "$MODE" == "ssh" ]]; then
                 "COMMAND_ARGS=$COMMAND_ARGS_STR" \
                 "INITIAL_DIR=$INITIAL_DIR" \
                 "SHARED_WORKSPACE=$SHARED_WORKSPACE" \
+                "SV_SESSION_ID=$SV_SESSION_ID" \
                 "VERBOSE=$VERBOSE" \
                 /bin/zsh -c 'export TMPDIR=$(mktemp -d); cd ~; exec /bin/zsh --login' || true
 else
@@ -751,6 +755,7 @@ else
             "COMMAND_ARGS=$COMMAND_ARGS_STR" \
             "INITIAL_DIR=$INITIAL_DIR" \
             "SHARED_WORKSPACE=$SHARED_WORKSPACE" \
+            "SV_SESSION_ID=$SV_SESSION_ID" \
             "VERBOSE=$VERBOSE" \
             /usr/bin/sandbox-exec -f "$SANDBOX_PROFILE" \
                 /bin/zsh -c 'export TMPDIR=$(mktemp -d); cd ~; exec /bin/zsh --login' || true


### PR DESCRIPTION
## Summary
- Move PATH setup and sandvault configuration from `.zshrc` to `.zshenv` so they're available in non-interactive shells
- Move directory initialization logic from `.zshrc` to `.zprofile` for proper login shell handling
- Add session-based locking (`SV_SESSION_ID`) to ensure configure script runs only once per session
- Add tests for initial directory fallback behavior