### PR TITLE
Update path-file ordering for $USER/bin

### DIFF
--- a/guest/home/.zprofile
+++ b/guest/home/.zprofile
@@ -7,5 +7,12 @@ elif [[ ! -r "$PWD" ]]; then
     cd "$HOME"
 fi
 
+# Add sandvault and user bin directories
+[[ -d "$HOME/bin" ]] && path=("$HOME/bin" $path)
+[[ -d "$HOME/.local/bin" ]] && path=("$HOME/.local/bin" $path)
+[[ -d "$HOME/user/bin" ]] && path=("$HOME/user/bin" $path)
+[[ -d "$HOME/user/.local/bin" ]] && path=("$HOME/user/.local/bin" $path)
+export PATH
+
 # Load user configuration
 [[ -f "$HOME/user/.zprofile" ]] && source "$HOME/user/.zprofile"

--- a/guest/home/.zshenv
+++ b/guest/home/.zshenv
@@ -14,12 +14,6 @@ if [[ -n "${SV_SESSION_ID:-}" ]]; then
     fi
 fi
 
-# Add sandvault and user bin directories
-[[ -d "$HOME/bin" ]] && path=("$HOME/bin" $path)
-[[ -d "$HOME/.local/bin" ]] && path=("$HOME/.local/bin" $path)
-[[ -d "$HOME/user/bin" ]] && path=("$HOME/user/bin" $path)
-[[ -d "$HOME/user/.local/bin" ]] && path=("$HOME/user/.local/bin" $path)
-export PATH
 
 # Load user configuration
 [[ -f "$HOME/user/.zshenv" ]] && source "$HOME/user/.zshenv"

--- a/scripts/tests
+++ b/scripts/tests
@@ -7,6 +7,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SV="$SCRIPT_DIR/../sv"
 HOST_USER="$USER"
 HOST_HOME="$HOME"
+SANDVAULT_USER="sandvault-$HOST_USER"
+SANDVAULT_HOME="/Users/$SANDVAULT_USER"
 
 # Colors
 RED='\033[0;31m'
@@ -83,6 +85,24 @@ assert_sandbox_fails() {
     fi
 }
 
+# Test that PATH order in sandbox is correct
+assert_sandbox_path_order() {
+    local name="$1"
+    local before="$2"
+    local after="$3"
+    ((TESTS_RUN++)) || true
+    local output path pos_before pos_after
+    output=$(sandbox_run "echo \$PATH")
+    path=":$output:"
+    pos_before=$(awk -v p="$path" -v b=":$before:" 'BEGIN { print index(p, b) }')
+    pos_after=$(awk -v p="$path" -v b=":$after:" 'BEGIN { print index(p, b) }')
+    if [[ "$pos_before" -gt 0 && "$pos_after" -gt 0 && "$pos_before" -lt "$pos_after" ]]; then
+        pass "$name"
+    else
+        fail "$name" "$before before $after" "$output"
+    fi
+}
+
 ###############################################################################
 echo "=== CLI Argument Tests ==="
 ###############################################################################
@@ -108,13 +128,20 @@ echo "=== Sandbox Identity Tests ==="
 ###############################################################################
 
 # Verify we're running as sandvault user, not host user
-assert_sandbox_contains "running as sandvault user" "whoami" "sandvault-$HOST_USER"
+assert_sandbox_contains "running as sandvault user" "whoami" "$SANDVAULT_USER"
 
 # Verify HOME is sandvault's home (single quotes intentional - evaluated in sandbox)
 # shellcheck disable=SC2016
 assert_sandbox_contains "HOME is sandvault home" 'echo $HOME' "/Users/sandvault-"
 # shellcheck disable=SC2016
 assert_sandbox_not_contains "HOME is not host home" 'echo $HOME' "$HOST_HOME"
+
+###############################################################################
+echo ""
+echo "=== Sandbox PATH Tests ==="
+###############################################################################
+
+assert_sandbox_path_order "\$USER/bin precedes /opt/homebrew/bin" "$SANDVAULT_HOME/bin" "/opt/homebrew/bin"
 
 ###############################################################################
 echo ""


### PR DESCRIPTION
Previously $USER/bin would appear after /opt/homebrew/bin, so our custom codex script would not get run.