### PR TITLE
Reduce Homebrew dependencies

### DIFF
--- a/guest/home/.zshenv
+++ b/guest/home/.zshenv
@@ -1,6 +1,20 @@
-# Add Homebrew bin directories
-[[ -d "/opt/homebrew/bin" ]] && path=("/opt/homebrew/bin" $path)
-[[ -d "/opt/homebrew/sbin" ]] && path=("/opt/homebrew/sbin" $path)
+# Setup Homebrew PATH
+case "$(uname -m)" in
+    arm64)
+        if [[ -x /opt/homebrew/bin/brew ]]; then
+            eval "$(/opt/homebrew/bin/brew shellenv)"
+        fi
+        ;;
+    x86_64)
+        if [[ -x /usr/local/bin/brew ]]; then
+            eval "$(/usr/local/bin/brew shellenv)"
+        fi
+        ;;
+    *)
+        echo >&2 "sv: error: unsupported architecture: $(uname -m)"
+        exit 1
+        ;;
+esac
 export PATH
 
 # Perform sandvault setup once per session

--- a/guest/home/bin/claude
+++ b/guest/home/bin/claude
@@ -1,10 +1,15 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-if [[ ! -x "$HOME/node_modules/bin/claude" ]]; then
-    echo >&2 "Installing claude..."
-    npm install --global --silent @anthropic-ai/claude-code@latest
+
+if [[ -x "$HOMEBREW_PREFIX/bin/claude" ]]; then
+    claude="$HOMEBREW_PREFIX/bin/claude"
+elif [[ -x "$HOME/node_modules/bin/claude" ]]; then
+    claude="$HOME/node_modules/bin/claude"
+else
+    echo >&2 "claude is not installed. Run: \`sv claude\` to install it."
+    exit 1
 fi
 
 echo "$USER: running claude --dangerously-skip-permissions"
-exec "$HOME/node_modules/bin/claude" --dangerously-skip-permissions "$@"
+exec "$claude" --dangerously-skip-permissions "$@"

--- a/guest/home/bin/codex
+++ b/guest/home/bin/codex
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-if [[ ! -x "$HOME/node_modules/bin/codex" ]]; then
-    echo >&2 "Installing codex..."
-    npm install --global --silent @openai/codex@latest
+if [[ -x "$HOMEBREW_PREFIX/bin/codex" ]]; then
+    codex="$HOMEBREW_PREFIX/bin/codex"
+elif [[ -x "$HOME/node_modules/bin/codex" ]]; then
+    codex="$HOME/node_modules/bin/codex"
+else
+    echo >&2 "codex is not installed. Run: \`sv codex\` to install it."
+    exit 1
 fi
 
 echo "$USER: running codex --dangerously-bypass-approvals-and-sandbox"
-exec "$HOME/node_modules/bin/codex" --dangerously-bypass-approvals-and-sandbox "$@"
+exec "$codex" --dangerously-bypass-approvals-and-sandbox "$@"

--- a/guest/home/bin/gemini
+++ b/guest/home/bin/gemini
@@ -1,10 +1,14 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
-if [[ ! -x "$HOME/node_modules/bin/gemini" ]]; then
-    echo >&2 "Installing gemini..."
-    npm install --global --silent @google/gemini-cli
+if [[ -x "$HOMEBREW_PREFIX/bin/gemini" ]]; then
+    gemini="$HOMEBREW_PREFIX/bin/gemini"
+elif [[ -x "$HOME/node_modules/bin/gemini" ]]; then
+    gemini="$HOME/node_modules/bin/gemini"
+else
+    echo >&2 "gemini is not installed. Run: \`sv gemini\` to install it."
+    exit 1
 fi
 
 echo "$USER: running gemini --yolo"
-exec "$HOME/node_modules/bin/gemini" --yolo "$@"
+exec "$gemini" --yolo "$@"

--- a/guest/home/configure
+++ b/guest/home/configure
@@ -87,10 +87,9 @@ defaults write com.apple.dt.Xcode IDECustomDerivedDataLocation ".DerivedData"
 USER_DIR="$SCRIPT_DIR/user"
 if [[ -d "$USER_DIR" ]]; then
     debug "Copying user directory contents to $HOME"
-   # Use the full path to the Homebrew rsync binary:
-    # - macOS' default rsync has different options
-    # - Homebrew's rsync may not be linked into the PATH
-    "$(brew --prefix rsync)/bin/rsync" \
+    # Use the system rsync to avoid Homebrew dependencies.
+    # - Homebrew's rsync has different options
+    /usr/bin/rsync \
         --quiet \
         --archive \
         --exclude='.git' \

--- a/scripts/tests
+++ b/scripts/tests
@@ -129,11 +129,16 @@ assert_sandbox_path_order() {
     local after="$3"
     ((TESTS_RUN++)) || true
     local output path pos_before pos_after
-    output=$(sandbox_run "echo \$PATH")
+    output=$(sandbox_run "printf '%s' \"\$PATH\"")
+    output="${output%%$'\n'*}"
+    if [[ -z "$output" ]]; then
+        fail "$name" "PATH output" "<empty>"
+        return
+    fi
     path=":$output:"
-    pos_before=$(awk -v p="$path" -v b=":$before:" 'BEGIN { print index(p, b) }')
-    pos_after=$(awk -v p="$path" -v b=":$after:" 'BEGIN { print index(p, b) }')
-    if [[ "$pos_before" -gt 0 && "$pos_after" -gt 0 && "$pos_before" -lt "$pos_after" ]]; then
+    pos_before="${path%%:$before:*}"
+    pos_after="${path%%:$after:*}"
+    if [[ "$pos_before" != "$path" && "$pos_after" != "$path" && ${#pos_before} -lt ${#pos_after} ]]; then
         pass "$name"
     else
         fail "$name" "$before before $after" "$output"

--- a/sv
+++ b/sv
@@ -88,36 +88,69 @@ show_version() {
     exit 0
 }
 
+brew_shellenv() {
+    case "$(uname -m)" in
+        arm64)
+            if [[ -x /opt/homebrew/bin/brew ]]; then
+                eval "$(/opt/homebrew/bin/brew shellenv)"
+                return 0
+            fi
+            ;;
+        x86_64)
+            if [[ -x /usr/local/bin/brew ]]; then
+                eval "$(/usr/local/bin/brew shellenv)"
+                return 0
+            fi
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+ensure_brew() {
+    if brew_shellenv; then
+        return 0
+    fi
+    debug "Installing Homebrew..."
+    env bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    brew_shellenv || abort "Homebrew install failed."
+}
+
+ensure_brew_tool() {
+    local tool="$1"
+    local cli_name="${2:-$tool}"
+    brew_shellenv || true
+    if command -v "$cli_name" &>/dev/null; then
+        return 0
+    fi
+    ensure_brew
+    debug "Installing $tool with Homebrew..."
+    if [[ "$VERBOSE" -lt 3 ]]; then
+        brew install --quiet "$tool"
+    else
+        brew install "$tool"
+    fi
+    if command -v "$cli_name" &>/dev/null; then
+        return 0
+    fi
+    warn "Homebrew installed $tool, but no '$cli_name' CLI was found in PATH. Will use \$HOME/node_modules/bin/$cli_name if present."
+    return 0
+}
+
 install_tools () {
-    # Install Homebrew
-    if ! command -v brew &> /dev/null ; then
-        debug "Installing Homebrew..."
-        /usr/bin/env bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-    fi
-
-    local TOOLS=()
-    TOOLS+=("flock")    # file locking
-    TOOLS+=("git")      # version control
-    TOOLS+=("netcat")   # test network connectivity
-    TOOLS+=("node")     # npm used to install claude, codex, gemini
-    TOOLS+=("python")   # python used for claude hooks
-    TOOLS+=("rsync")    # file synchronization
-    TOOLS+=("uv")       # run python scripts with uv
-
-    # Only install tools if necessary
-    local LIST_COUNT
-    local BREW_COUNT
-    LIST_COUNT="$(echo "${TOOLS[@]}" | wc -w)"
-    BREW_COUNT="$(brew list --versions "${TOOLS[@]}" | awk '{print $1}' | wc -w || true)"
-    if [[ "$LIST_COUNT" != "$BREW_COUNT" ]]; then
-        debug "Installing tools..."
-        trace "brew install " "${TOOLS[@]}" "..."
-        if [[ "$VERBOSE" -lt 3 ]]; then
-            brew install --quiet "${TOOLS[@]}"
-        else
-            brew install "${TOOLS[@]}"
-        fi
-    fi
+    # Install homebrew tools only when the user invokes them.
+    case "${COMMAND:-}" in
+        claude)
+            ensure_brew_tool "claude-code" "claude"
+            ;;
+        codex)
+            ensure_brew_tool "codex" "codex"
+            ;;
+        gemini)
+            ensure_brew_tool "gemini-cli" "gemini"
+            ;;
+    esac
 }
 
 force_cleanup_sandvault_processes() {
@@ -143,32 +176,37 @@ force_cleanup_sandvault_processes() {
 
 register_session() {
     mkdir -p "$SESSION_DIR"
-    (
-        flock -x 200
-        local count
-        count=$(cat "$SESSION_FILE" 2>/dev/null || echo 0)
+    local new_count
+    new_count=$(/usr/bin/lockf "$SESSION_FILE.lock" /bin/bash -c '
+        session_file=$1
+        count=$(cat "$session_file" 2>/dev/null || echo 0)
         [[ "$count" =~ ^[0-9]+$ ]] || count=0
-        echo $((count + 1)) > "$SESSION_FILE"
-        trace "Session registered (count: $((count + 1)))"
-    ) 200>"$SESSION_FILE.flock"
+        new_count=$((count + 1))
+        echo "$new_count" > "$session_file"
+        echo "$new_count"
+    ' bash "$SESSION_FILE")
+    trace "Session registered (count: $new_count)"
 }
 
 unregister_session() {
     mkdir -p "$SESSION_DIR"
-    (
-        flock -x 200
-        local count
-        count=$(cat "$SESSION_FILE" 2>/dev/null || echo 1)
+    local prev_count
+    local new_count
+    read -r prev_count new_count < <(/usr/bin/lockf "$SESSION_FILE.lock" /bin/bash -c '
+        session_file=$1
+        count=$(cat "$session_file" 2>/dev/null || echo 1)
         [[ "$count" =~ ^[0-9]+$ ]] || count=1
-        echo $((count - 1)) > "$SESSION_FILE"
-        trace "Session unregistered (count: $((count - 1)))"
-        if [[ "$count" -le 1 ]]; then
-            trace "Last session exited; cleaning up sandvault processes"
-            force_cleanup_sandvault_processes
-        else
-            trace "Other sessions still active; skipping cleanup"
-        fi
-    ) 200>"$SESSION_FILE.flock"
+        new_count=$((count - 1))
+        echo "$new_count" > "$session_file"
+        echo "$count $new_count"
+    ' bash "$SESSION_FILE")
+    trace "Session unregistered (count: $new_count)"
+    if [[ "$prev_count" -le 1 ]]; then
+        trace "Last session exited; cleaning up sandvault processes"
+        force_cleanup_sandvault_processes
+    else
+        trace "Other sessions still active; skipping cleanup"
+    fi
 }
 
 configure_shared_folder_permssions() {
@@ -538,18 +576,16 @@ sudo /bin/chmod 0750 "/Users/$SANDVAULT_USER"
 
 # Copy files preserving permissions for contents only
 # (trailing slash on destination ensures it isn't modified)
-# Use the full path to the homebrew rsync binary:
-# - macOS' default rsync has different options
-# - Homebrew rsync may not be linked into the PATH
-"$(brew --prefix rsync)/bin/rsync" \
+# Use the system rsync to avoid Homebrew dependencies.
+/usr/bin/rsync \
     --quiet \
     --links \
     --checksum \
     --recursive \
     --perms \
     --times \
-    --chown="$SANDVAULT_USER:$SANDVAULT_GROUP" \
     "$WORKSPACE/guest/home/." "/Users/$SANDVAULT_USER/"
+sudo /usr/sbin/chown -R "$SANDVAULT_USER:$SANDVAULT_GROUP" "/Users/$SANDVAULT_USER"
 EOF
     sudo mkdir -p "$(dirname "$SUDOERS_BUILD_HOME_SCRIPT_NAME")"
     # shellcheck disable=SC2154 # SUDOERS_BUILD_HOME_SCRIPT_CONTENTS is referenced but not assigned (yes it is)
@@ -739,6 +775,7 @@ if [[ "$MODE" == "ssh" ]]; then
                 "SHARED_WORKSPACE=$SHARED_WORKSPACE" \
                 "SV_SESSION_ID=$SV_SESSION_ID" \
                 "VERBOSE=$VERBOSE" \
+                "PATH=/usr/bin:/bin:/usr/sbin:/sbin" \
                 /bin/zsh -c "$ZSH_COMMAND"
     then
         :
@@ -774,6 +811,7 @@ else
             "SHARED_WORKSPACE=$SHARED_WORKSPACE" \
             "SV_SESSION_ID=$SV_SESSION_ID" \
             "VERBOSE=$VERBOSE" \
+            "PATH=/usr/bin:/bin:/usr/sbin:/sbin" \
             /usr/bin/sandbox-exec -f "$SANDBOX_PROFILE" \
                 /bin/zsh -c "$ZSH_COMMAND"
     then


### PR DESCRIPTION
- Rely more on macOS built-in tools when available rather than those from Homebrew
- Install Claude/Codex/Gemini from Homebrew rather than `npm`
- Blow up if running on an unsupported architecture