### PR TITLE
Fix ACL traversal for sandvault shared workspace

### DIFF
--- a/sv
+++ b/sv
@@ -81,7 +81,7 @@ fi
 ###############################################################################
 # Resources
 ###############################################################################
-readonly VERSION="1.1.16"
+readonly VERSION="1.1.17"
 
 # Each user on the computer can have their own sandvault
 readonly SANDVAULT_USER="sandvault-$USER"


### PR DESCRIPTION
Problem: the shared ACL lacked 'search', so sandvault users could not traverse directories with restrictive POSIX perms (e.g. 700), causing 'Permission denied' even without sandbox-exec. Add search/list to the default ACL so recursive access works for those directories.