### PR TITLE
Handle user directory being a symlink.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,4 @@ guest/home/.gitconfig
 guest/home/.ssh/authorized_keys
 
 # User directory for storing files that are not committed
-guest/home/user/
+guest/home/user

--- a/sv
+++ b/sv
@@ -823,6 +823,7 @@ cd "/Users/$SANDVAULT_USER/"
     --itemize-changes \
     --out-format="%n" \
     --links \
+    --copy-unsafe-links \
     --checksum \
     --recursive \
     --perms \


### PR DESCRIPTION
Ensure that `rsync` uses `--copy-unsafe-links` to avoid symlink issues and `.gitignore` ignores the user directory if it's a symlink.