### PR TITLE
Release v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 All notable user-facing changes to SandVault are documented in this file.
 
-## [1.2.0] - 2026-04-10
+## [1.2.1] - 2026-04-10
 
-_No user-facing changes. Internal CI improvements._
+### Fixed
+
+- Fix version number not being updated in `sv` binary during 1.2.0 release ([#94](https://github.com/webcoyote/sandvault/pull/94))
+
+### Thanks to 1 contributor!
+
+- [@webcoyote](https://github.com/webcoyote)
 
 ## [1.1.34] - 2026-04-09
 

--- a/sv
+++ b/sv
@@ -136,7 +136,7 @@ fi
 ###############################################################################
 # Resources
 ###############################################################################
-readonly VERSION="1.1.34"
+readonly VERSION="1.2.1"
 
 # Re-entrancy detection: if SV_SESSION_ID is already set, we're already in sandvault.
 NESTED=false


### PR DESCRIPTION
## [1.2.1] - 2026-04-10

### Fixed

- Fix version number not being updated in `sv` binary during 1.2.0 release ([#94](https://github.com/webcoyote/sandvault/pull/94))

### Thanks to 1 contributor!

- [@webcoyote](https://github.com/webcoyote)