### PR TITLE
Release v1.2.3

### DIFF
--- a/.github/scripts/tag-version
+++ b/.github/scripts/tag-version
@@ -28,7 +28,7 @@ if [[ "$CURRENT_BRANCH" != "$DEFAULT_BRANCH" ]]; then
 fi
 
 # --- Read current version ---
-CURRENT_VERSION=$(./sv --version | awk '{print $NF}')
+CURRENT_VERSION=$(awk -F'"' '/^readonly VERSION="[0-9.]*"/ {print $2; exit}' ./sv)
 if [[ -z "$CURRENT_VERSION" ]]; then
   echo >&2 "Error: Could not parse version from ./sv --version"
   exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable user-facing changes to SandVault are documented in this file.
 
+## [1.2.3] - 2026-04-10
+
+_No user-facing changes. This release includes internal CI and release tooling improvements._
+
+### Thanks to 1 contributor!
+
+- [@webcoyote](https://github.com/webcoyote)
+
 ## [1.2.2] - 2026-04-10
 
 _No user-facing changes. This release includes internal CI and release tooling improvements._

--- a/sv
+++ b/sv
@@ -136,7 +136,7 @@ fi
 ###############################################################################
 # Resources
 ###############################################################################
-readonly VERSION="1.2.2"
+readonly VERSION="1.2.3"
 
 # Re-entrancy detection: if SV_SESSION_ID is already set, we're already in sandvault.
 NESTED=false


### PR DESCRIPTION
## [1.2.3] - 2026-04-10

_No user-facing changes. This release includes internal CI and release tooling improvements._

### Thanks to 1 contributor!

- [@webcoyote](https://github.com/webcoyote)