### PR TITLE
Release v1.2.4

### DIFF
--- a/.github/scripts/tag-version
+++ b/.github/scripts/tag-version
@@ -9,28 +9,13 @@ trap 'echo "${BASH_SOURCE[0]}: line $LINENO: $BASH_COMMAND: exitcode $?"' ERR
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
-# --- Guard: only run on the default branch ---
-DEFAULT_BRANCH="$(git symbolic-ref -q --short refs/remotes/origin/HEAD 2>/dev/null || true)"
-DEFAULT_BRANCH="${DEFAULT_BRANCH#origin/}"
-if [[ -z "$DEFAULT_BRANCH" ]]; then
-  # In GitHub Actions, origin/HEAD is often not set; use the API instead
-  DEFAULT_BRANCH="$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || true)"
-fi
-if [[ -z "$DEFAULT_BRANCH" ]]; then
-  echo >&2 "Error: Unable to determine default branch."
-  exit 1
-fi
-
-CURRENT_BRANCH="$(git rev-parse --abbrev-ref HEAD)"
-if [[ "$CURRENT_BRANCH" != "$DEFAULT_BRANCH" ]]; then
-  echo "Not on default branch ($DEFAULT_BRANCH), skipping. Current: $CURRENT_BRANCH"
-  exit 0
-fi
+# Note: branch guard is handled by the CI workflow (github.ref == 'refs/heads/main').
+# Do not duplicate it here — detached-HEAD checkouts in CI break git-based detection.
 
 # --- Read current version ---
 CURRENT_VERSION=$(awk -F'"' '/^readonly VERSION="[0-9.]*"/ {print $2; exit}' ./sv)
 if [[ -z "$CURRENT_VERSION" ]]; then
-  echo >&2 "Error: Could not parse version from ./sv --version"
+  echo >&2 "Error: Could not parse version"
   exit 1
 fi
 
@@ -44,5 +29,7 @@ fi
 
 # --- Create and push the tag on HEAD (the merge commit) ---
 echo "Tagging $TAG_NAME on $(git rev-parse --short HEAD)"
+git config user.name  "github-actions[bot]"
+git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 git tag -a "$TAG_NAME" -m "Version $CURRENT_VERSION"
 git push origin "$TAG_NAME"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable user-facing changes to SandVault are documented in this file.
 
+## [1.2.4] - 2026-04-10
+
+_No user-facing changes. This release includes internal release tooling fixes._
+
+### Thanks to 1 contributor!
+
+- [@webcoyote](https://github.com/webcoyote)
+
 ## [1.2.3] - 2026-04-10
 
 _No user-facing changes. This release includes internal CI and release tooling improvements._

--- a/sv
+++ b/sv
@@ -136,7 +136,7 @@ fi
 ###############################################################################
 # Resources
 ###############################################################################
-readonly VERSION="1.2.3"
+readonly VERSION="1.2.4"
 
 # Re-entrancy detection: if SV_SESSION_ID is already set, we're already in sandvault.
 NESTED=false


### PR DESCRIPTION
## [1.2.4] - 2026-04-10

_No user-facing changes. This release includes internal release tooling fixes._

### Thanks to 1 contributor!

- [@webcoyote](https://github.com/webcoyote)