### PR TITLE
Release v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable user-facing changes to SandVault are documented in this file.
 
+## [1.5.0] - 2026-04-12
+
+### Fixed
+- Fix native install for Codex and Gemini agents when nvm is in use — `.npmrc` prefix setting was breaking nvm
+
+### Thanks to 1 contributor!
+
+- [@webcoyote](https://github.com/webcoyote)
+
 ## [1.4.0] - 2026-04-12
 
 ### Fixed

--- a/guest/home/.npmrc
+++ b/guest/home/.npmrc
@@ -1,2 +1,0 @@
-prefix=${HOME}/node_modules
-

--- a/guest/home/bin/codex
+++ b/guest/home/bin/codex
@@ -4,10 +4,11 @@ trap 'echo "${BASH_SOURCE[0]}: line $LINENO: $BASH_COMMAND: exitcode $?"' ERR
 
 unset CODEX
 if [[ "${SV_NATIVE_INSTALL:-}" == "true" ]]; then
-    NPM_BIN="$(npm prefix -g)/bin"
+    NPM_PREFIX="${HOME}/node_modules"
+    NPM_BIN="$NPM_PREFIX/bin"
     if [[ ! -x "$NPM_BIN/codex" ]]; then
         echo >&2 "Installing Codex natively with npm..."
-        npm install -g @openai/codex
+        npm install --prefix "$NPM_PREFIX" -g @openai/codex
     fi
     CODEX="$NPM_BIN/codex"
 elif command -v brew &>/dev/null ; then

--- a/guest/home/bin/gemini
+++ b/guest/home/bin/gemini
@@ -4,10 +4,11 @@ trap 'echo "${BASH_SOURCE[0]}: line $LINENO: $BASH_COMMAND: exitcode $?"' ERR
 
 unset GEMINI
 if [[ "${SV_NATIVE_INSTALL:-}" == "true" ]]; then
-    NPM_BIN="$(npm prefix -g)/bin"
+    NPM_PREFIX="${HOME}/node_modules"
+    NPM_BIN="$NPM_PREFIX/bin"
     if [[ ! -x "$NPM_BIN/gemini" ]]; then
         echo >&2 "Installing Gemini CLI natively with npm..."
-        npm install -g @google/gemini-cli
+        npm install --prefix "$NPM_PREFIX" -g @google/gemini-cli
     fi
     GEMINI="$NPM_BIN/gemini"
 elif command -v brew &>/dev/null ; then

--- a/sv
+++ b/sv
@@ -136,7 +136,7 @@ fi
 ###############################################################################
 # Resources
 ###############################################################################
-readonly VERSION="1.4.0"
+readonly VERSION="1.5.0"
 
 # Re-entrancy detection: if SV_SESSION_ID is already set, we're already in sandvault.
 NESTED=false


### PR DESCRIPTION
## [1.5.0] - 2026-04-12

### Fixed
- Fix native install for Codex and Gemini agents when nvm is in use — `.npmrc` prefix setting was breaking nvm

### Thanks to 1 contributor!

- [@webcoyote](https://github.com/webcoyote)