### PR TITLE
Add OpenCode agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SandVault (`sv`) manages a limited user account to sandbox shell commands and AI
 </br>
 </br>
 
-- **AI ready** - Includes Claude Code, OpenAI Codex, Google Gemini
+- **AI ready** - Includes Claude Code, OpenAI Codex, OpenCode, Google Gemini
 - **Fast context switching** - No VM overhead; instant user switching
 - **Passwordless** - switch accounts without a prompt (after setup)
 - **Shared workspace** - joint access to `/Users/Shared/sv-$USER`
@@ -79,6 +79,10 @@ Install via git:
 # Run OpenAI Codex in the sandbox
 # shortcut: sv co
   sv codex
+
+# Run OpenCode in the sandbox
+# shortcut: sv o
+  sv opencode
 
 # Run Google Gemini in the sandbox
 # shortcut: sv g
@@ -157,6 +161,7 @@ By default, SandVault installs AI tools via Homebrew on the host side. With `--n
 
 - **Claude Code** — installed via `curl -fsSL https://claude.ai/install.sh | bash`
 - **Codex** — installed via `npm install -g @openai/codex`
+- **OpenCode** — installed via `curl -fsSL https://opencode.ai/install | bash`
 - **Gemini** — installed via `npm install -g @google/gemini-cli`
 
 Tools are installed on first run and reused on subsequent runs.
@@ -168,6 +173,7 @@ sv -N claude
 
 # Works with all AI agents
 sv -N codex
+sv -N opencode
 sv -N gemini
 ```
 
@@ -425,6 +431,7 @@ After exploring Docker containers, Podman, sandbox-exec, and virtualization, I n
 - Provides meaningful isolation without too much complexity
 - Runs Claude Code with `--dangerously-skip-permissions`
 - Runs OpenAI Codex with `--dangerously-bypass-approvals-and-sandbox`
+- Runs OpenCode with `--dangerously-skip-permissions`
 - Runs Google Gemini with `--yolo`
 - Maintains a clean separation between trusted and untrusted code
 

--- a/guest/home/bin/opencode
+++ b/guest/home/bin/opencode
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -Eeuo pipefail
+trap 'echo "${BASH_SOURCE[0]}: line $LINENO: $BASH_COMMAND: exitcode $?"' ERR
+
+unset OPENCODE
+if [[ "${SV_NATIVE_INSTALL:-}" == "true" ]]; then
+    if [[ ! -x "$HOME/.local/bin/opencode" ]]; then
+        echo >&2 "Installing OpenCode natively..."
+        curl -fsSL https://opencode.ai/install | XDG_BIN_DIR="$HOME/.local/bin" bash
+    fi
+    OPENCODE="$HOME/.local/bin/opencode"
+elif command -v brew &>/dev/null ; then
+    HOMEBREW_PREFIX="${HOMEBREW_PREFIX:-"$(brew --prefix)"}"
+    if [[ -x "$HOMEBREW_PREFIX/bin/opencode" ]]; then
+        # Homebrew install
+        OPENCODE="$HOMEBREW_PREFIX/bin/opencode"
+    fi
+fi
+
+if [[ -z "${OPENCODE:-}" || ! -x "$OPENCODE" ]]; then
+    echo >&2 "ERROR: opencode is not installed"
+    exit 1
+fi
+
+echo "$USER: running opencode --dangerously-skip-permissions"
+exec "$OPENCODE" --dangerously-skip-permissions "$@"

--- a/scripts/tests
+++ b/scripts/tests
@@ -289,6 +289,30 @@ run_tests() {
     }
     queue_test test_help
 
+    test_help_lists_opencode() {
+        local output
+        output=$(sv_cmd --help 2>&1)
+        if [[ "$output" == *"opencode"* ]]; then
+            pass "--help lists opencode"
+        else
+            fail "--help lists opencode" "opencode command" "$output"
+        fi
+    }
+    queue_test test_help_lists_opencode
+
+    test_opencode_wrapper_uses_skip_permissions() {
+        if [[ -x "$SCRIPT_DIR/../guest/home/bin/opencode" ]] \
+            && grep -F -- "--dangerously-skip-permissions" \
+                "$SCRIPT_DIR/../guest/home/bin/opencode" &>/dev/null; then
+            pass "opencode wrapper uses skip permissions"
+        else
+            fail "opencode wrapper uses skip permissions" \
+                "executable wrapper with --dangerously-skip-permissions" \
+                "$SCRIPT_DIR/../guest/home/bin/opencode"
+        fi
+    }
+    queue_test test_opencode_wrapper_uses_skip_permissions
+
     # Unknown option
     test_unknown_option() {
         local output
@@ -376,7 +400,7 @@ run_tests() {
         fi
         local failed=false
         local link
-        for link in claude codex gemini; do
+        for link in claude codex opencode gemini; do
             if [[ -L "$brew_prefix/bin/$link" ]]; then
                 local link_perms
                 link_perms=$(/usr/bin/stat -f "%Lp" "$brew_prefix/bin/$link")

--- a/sv
+++ b/sv
@@ -334,6 +334,9 @@ install_tools () {
         codex)
             ensure_brew_tool "codex" "codex"
             ;;
+        opencode)
+            ensure_brew_tool "anomalyco/tap/opencode" "opencode"
+            ;;
         gemini)
             ensure_brew_tool "gemini-cli" "gemini"
             ;;
@@ -635,12 +638,13 @@ show_help() {
     echo "Commands:"
     echo "  cl, claude [PATH]    Open Claude Code in sandvault"
     echo "  co, codex  [PATH]    Open OpenAI Codex in sandvault"
+    echo "  o,  opencode [PATH]  Open OpenCode in sandvault"
     echo "  g,  gemini [PATH]    Open Google Gemini in sandvault"
     echo "  s, shell   [PATH]    Open shell in sandvault"
     echo "  b, build             Build sandvault"
     echo "  u, uninstall         Remove sandvault; keep shared files"
     echo ""
-    echo "Arguments after -- are passed to the command (claude, gemini, codex, shell)"
+    echo "Arguments after -- are passed to the command (claude, codex, opencode, gemini, shell)"
     echo ""
     echo "Environment:"
     echo "  SANDVAULT_ARGS       Default arguments (prepended to command line)"
@@ -747,6 +751,10 @@ case "${1:-}" in
         ;;
     co|codex)
         COMMAND=codex
+        INITIAL_DIR="${2:-}"
+        ;;
+    o|opencode)
+        COMMAND=opencode
         INITIAL_DIR="${2:-}"
         ;;
     g|gemini)
@@ -1264,7 +1272,7 @@ fi
 # Run the application
 ###############################################################################
 if [[ -n "$CLONE_REPOSITORY" ]]; then
-    CLONE_SUPPORTED_COMMANDS=(shell claude codex gemini)
+    CLONE_SUPPORTED_COMMANDS=(shell claude codex opencode gemini)
     for supported_command in "${CLONE_SUPPORTED_COMMANDS[@]}"; do
         if [[ "${COMMAND:-shell}" == "$supported_command" ]]; then
             break
@@ -1397,7 +1405,7 @@ if [[ "$FIX_PERMISSIONS" == "true" ]]; then
     # Fix homebrew symlinks for any installed tools
     # shellcheck disable=SC2310 # brew_shellenv intentionally used in condition
     if brew_shellenv 2>/dev/null; then
-        for tool_cli in claude codex gemini; do
+        for tool_cli in claude codex opencode gemini; do
             brew_link="$(brew --prefix)/bin/$tool_cli"
             if [[ -L "$brew_link" ]]; then
                 link_perms=$(/usr/bin/stat -f "%Lp" "$brew_link")


### PR DESCRIPTION
- let `sv` launch `opencode` the same way as the other agents
- use `--dangerously-skip-permissions` so sandbox sessions stay non-interactive
- document and test the new command so the wrapper and help text stay aligned