### PR TITLE
Fix opencode permission bypass

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,7 +431,7 @@ After exploring Docker containers, Podman, sandbox-exec, and virtualization, I n
 - Provides meaningful isolation without too much complexity
 - Runs Claude Code with `--dangerously-skip-permissions`
 - Runs OpenAI Codex with `--dangerously-bypass-approvals-and-sandbox`
-- Runs OpenCode with `--dangerously-skip-permissions`
+- Runs OpenCode with `OPENCODE_PERMISSION='{"*":"allow"}'`
 - Runs Google Gemini with `--yolo`
 - Maintains a clean separation between trusted and untrusted code
 

--- a/guest/home/bin/opencode
+++ b/guest/home/bin/opencode
@@ -22,5 +22,6 @@ if [[ -z "${OPENCODE:-}" || ! -x "$OPENCODE" ]]; then
     exit 1
 fi
 
-echo "$USER: running opencode --dangerously-skip-permissions"
-exec "$OPENCODE" --dangerously-skip-permissions "$@"
+export OPENCODE_PERMISSION='{"*":"allow"}'
+echo "$USER: running opencode with OPENCODE_PERMISSION='${OPENCODE_PERMISSION}'"
+exec "$OPENCODE" "$@"

--- a/scripts/tests
+++ b/scripts/tests
@@ -302,12 +302,12 @@ run_tests() {
 
     test_opencode_wrapper_uses_skip_permissions() {
         if [[ -x "$SCRIPT_DIR/../guest/home/bin/opencode" ]] \
-            && grep -F -- "--dangerously-skip-permissions" \
+            && grep -F -- "OPENCODE_PERMISSION" \
                 "$SCRIPT_DIR/../guest/home/bin/opencode" &>/dev/null; then
             pass "opencode wrapper uses skip permissions"
         else
             fail "opencode wrapper uses skip permissions" \
-                "executable wrapper with --dangerously-skip-permissions" \
+                "executable wrapper with OPENCODE_PERMISSION" \
                 "$SCRIPT_DIR/../guest/home/bin/opencode"
         fi
     }


### PR DESCRIPTION
- `--dangerously-skip-permissions` only exists on the `opencode run` subcommand, not the default TUI
- Use `OPENCODE_PERMISSION='{"*":"allow"}'` env var which works for all modes

Tested this more heavily locally and working as expected now 🤦🏻 