### PR TITLE
Move session files to shared workspace so they can be deleted by user

### DIFF
--- a/guest/home/.zshenv
+++ b/guest/home/.zshenv
@@ -1,7 +1,11 @@
 # Perform sandvault setup once per session
 if [[ -n "${SV_SESSION_ID:-}" ]]; then
-    sv_session_lock="/tmp/sandvault-configure-$SV_SESSION_ID"
-    trap 'rm -f "/tmp/sandvault-configure-$SV_SESSION_ID" 2>/dev/null || true' EXIT
+    # Use $SHARED_WORKSPACE/tmp for the lock file so the host user can delete it
+    # during session cleanup. /tmp has the sticky bit set, which prevents
+    # users from deleting files they don't own.
+    sv_session_dir="${SHARED_WORKSPACE:-}/tmp"
+    mkdir -p "$sv_session_dir"
+    sv_session_lock="$sv_session_dir/sv-session-$SV_SESSION_ID"
     if [[ ! -e "$sv_session_lock" ]]; then
         : > "$sv_session_lock"
 

--- a/sv
+++ b/sv
@@ -500,6 +500,10 @@ register_session() {
 }
 
 unregister_session() {
+    # Per-session cleanup
+    [[ "$USE_BROWSER" == "true" ]] && stop_chrome
+    rm -f "$SHARED_WORKSPACE/tmp/sv-session-$SV_SESSION_ID" 2>/dev/null || true
+
     mkdir -p "$SESSION_DIR"
     local prev_count
     local new_count
@@ -551,6 +555,7 @@ uninstall() {
     info "Uninstalling..."
     force_cleanup_sandvault_processes force-all
     rm -rf "$SESSION_DIR"/chrome-data-* "$SESSION_DIR"/chrome-*.log
+    rm -f /tmp/sandvault-configure-* 2>/dev/null || true
 
     # Remove the install marker file first; it's a sentinel for "everything is complete".
     # By removing it first we force a rebuild if the user wants to run this again.
@@ -1511,7 +1516,7 @@ if [[ "$NESTED" == "false" ]]; then
     if [[ "$USE_BROWSER" == "true" ]]; then
         start_chrome
     fi
-    trap 'sv_exit_code=$?; set +e; [[ "$USE_BROWSER" == "true" ]] && stop_chrome; unregister_session; exit $sv_exit_code' EXIT
+    trap 'sv_exit_code=$?; set +e; unregister_session; exit $sv_exit_code' EXIT
 elif [[ "$USE_BROWSER" == "true" ]]; then
     # Nested session with --browser: Chrome cannot be launched inside the
     # sandbox, so the parent session must already have started it.


### PR DESCRIPTION
Files in /tmp cannot be deleted by user because that directory has the sticky
bit set, which only allows sandvault-user and root to delete files created by
sandvault-user
