### PR TITLE
Release v1.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable user-facing changes to SandVault are documented in this file.
 
+## [1.10.0] - 2026-04-18
+
+### Added
+- Add iOS simulator sandbox bridge for testing mobile apps in the sandbox ([#118](https://github.com/webcoyote/sandvault/pull/118))
+- Make AI agents aware of browser endpoint via `SV_BROWSER_ENDPOINT` ([#116](https://github.com/webcoyote/sandvault/pull/116))
+
+### Changed
+- Move session files to shared workspace so users can manage them directly ([#117](https://github.com/webcoyote/sandvault/pull/117))
+
+### Fixed
+- Suppress noisy process-kill notifications when closing iOS simulator or browser sessions ([#118](https://github.com/webcoyote/sandvault/pull/118))
+
+### Thanks to 1 contributor!
+
+- [@webcoyote](https://github.com/webcoyote)
+
 ## [1.9.0] - 2026-04-15
 
 ### Fixed

--- a/sv
+++ b/sv
@@ -136,7 +136,7 @@ fi
 ###############################################################################
 # Resources
 ###############################################################################
-readonly VERSION="1.9.0"
+readonly VERSION="1.10.0"
 
 # Re-entrancy detection: if SV_SESSION_ID is already set, we're already in sandvault.
 NESTED=false


### PR DESCRIPTION
## [1.10.0] - 2026-04-18

### Added
- Add iOS simulator sandbox bridge for testing mobile apps in the sandbox (#118)
- Make AI agents aware of browser endpoint via `SV_BROWSER_ENDPOINT` (#116)

### Changed
- Move session files to shared workspace so users can manage them directly (#117)

### Fixed
- Suppress noisy process-kill notifications when closing iOS simulator or browser sessions (#118)

### Thanks to 1 contributor!

- [@webcoyote](https://github.com/webcoyote)