### PR TITLE
Move "sv --clone REPO" functionality to a separate script

### DIFF
--- a/scripts/tests
+++ b/scripts/tests
@@ -568,6 +568,183 @@ run_tests() {
     queue_test test_clone_flag_rejected
 
     ###############################################################################
+    # sv-clone Tests
+    #
+    # sv-clone runs as the host user (not inside the sandbox), so these tests
+    # call the script directly rather than going through sv_cmd.  They are
+    # gated on mode_label to run only once (default mode, not SSH).
+    ###############################################################################
+    SV_CLONE_BASE="$SCRIPT_DIR/../sv-clone"
+
+    if [[ "$mode_label" != *" --ssh" && -x "$SV_CLONE_BASE" ]]; then
+
+    sv_clone_cmd() {
+        "$bash_path" "$SV_CLONE_BASE" "$@"
+    }
+
+    # Test cloning a local repository via sv-clone and wiring remotes.
+    test_sv_clone_local() {
+        local src_repository
+        local clone_name
+        local clone_path
+        local output
+        local status
+        local host_origin
+        local remote_output
+        local expected_upstream
+
+        src_repository="$(git -C "$SCRIPT_DIR/.." rev-parse --show-toplevel 2>/dev/null || true)"
+        if [[ -z "$src_repository" || ! -d "$src_repository/.git" ]]; then
+            fail "sv-clone clones local repository" "current repository available" "$src_repository"
+            return
+        fi
+
+        clone_name="$(basename "$src_repository")"
+        clone_path="$SHARED_WORKSPACE/repos/$clone_name"
+        expected_upstream="$(git -C "$src_repository" remote get-url origin 2>/dev/null || true)"
+        if [[ -z "$expected_upstream" ]]; then
+            fail "sv-clone clones local repository" "source repository has origin remote" "$src_repository"
+            return
+        fi
+
+        # Clean up any previous clone so the test is idempotent.
+        sv_cmd s -- rm -rf "$clone_path" >/dev/null 2>&1
+
+        # sv-clone clones the repo then exec's sv with the repo path.
+        # Pass "-- --no-build shell -- true" so the launched sv session
+        # exits immediately without requiring an interactive shell.
+        set +e
+        output=$(sv_clone_cmd "$src_repository" -- --no-build shell -- true 2>&1)
+        status=$?
+        set -e
+        if [[ "$status" -ne 0 ]]; then
+            fail "sv-clone clones local repository" "exit 0" "$status | $output"
+            return
+        fi
+
+        # Verify the clone was created.
+        if [[ ! -d "$clone_path/.git" ]]; then
+            fail "sv-clone clones local repository" "$clone_path/.git exists" "directory not found"
+            return
+        fi
+
+        # Host origin should still point at the upstream remote.
+        host_origin="$(git -C "$src_repository" remote get-url origin 2>/dev/null)"
+        if [[ "$host_origin" != "$expected_upstream" ]]; then
+            fail "local repository keeps origin at upstream" "$expected_upstream" "$host_origin"
+            return
+        fi
+
+        # sv-clone should have added a 'sandvault' remote to the local repo.
+        remote_output="$(git -C "$src_repository" remote get-url sandvault 2>/dev/null)"
+        if [[ "$remote_output" != "$clone_path" ]]; then
+            fail "local repository gets sandvault remote" "$clone_path" "$remote_output"
+            return
+        fi
+
+        # The clone's origin should point to the upstream URL.
+        set +e
+        remote_output=$(git -C "$clone_path" config remote.origin.url 2>&1)
+        status=$?
+        set -e
+        if [[ "$status" -ne 0 || "$remote_output" != *"$expected_upstream"* ]]; then
+            fail "sv-clone clone origin points to upstream" "$expected_upstream" "$status | $remote_output"
+            return
+        fi
+
+        pass "sv-clone clones local repository"
+
+        sv_cmd s -- rm -rf "$clone_path" >/dev/null 2>&1
+    }
+    queue_test test_sv_clone_local
+
+    # Clone tests share the same destination repo name (`sandvault`) and race if parallelized.
+    wait_for_all_running_tests
+
+    # Test cloning an HTTPS repository via sv-clone.
+    test_sv_clone_https() {
+        local clone_path
+        local output
+        local status
+        local remote_output
+        local https_repository
+
+        https_repository="https://github.com/webcoyote/sandvault.git"
+        clone_path="$SHARED_WORKSPACE/repos/sandvault"
+
+        # Start clean to avoid stale clone state influencing assertions.
+        sv_cmd s -- rm -rf "$clone_path" >/dev/null 2>&1
+
+        set +e
+        output=$(sv_clone_cmd "$https_repository" -- --no-build shell -- true 2>&1)
+        status=$?
+        set -e
+        if [[ "$status" -ne 0 ]]; then
+            fail "sv-clone clones HTTPS repository" "exit 0" "$status | $output"
+            return
+        fi
+
+        if [[ ! -d "$clone_path/.git" ]]; then
+            fail "sv-clone clones HTTPS repository" "$clone_path/.git exists" "directory not found"
+            return
+        fi
+
+        # Use "git config remote.origin.url" instead of
+        # "git remote get-url" to avoid issues with
+        # git url remapping with insteadOf override.
+        set +e
+        remote_output=$(git -C "$clone_path" config remote.origin.url 2>&1)
+        status=$?
+        set -e
+        if [[ "$status" -ne 0 || "$remote_output" != *"$https_repository"* ]]; then
+            fail "sv-clone HTTPS clone origin points to remote URL" "$https_repository" "$status | $remote_output"
+            return
+        fi
+
+        pass "sv-clone clones HTTPS repository"
+        sv_cmd s -- rm -rf "$clone_path" >/dev/null 2>&1
+    }
+    queue_test test_sv_clone_https
+
+    # Test that sv-clone rejects missing repository argument.
+    test_sv_clone_rejects_missing_arg() {
+        local output
+        local status
+
+        set +e
+        output=$(sv_clone_cmd 2>&1)
+        status=$?
+        set -e
+
+        if [[ "$status" -ne 0 && "$output" == *"Usage:"* ]]; then
+            pass "sv-clone rejects missing repository argument"
+        else
+            fail "sv-clone rejects missing repository argument" "non-zero exit with Usage message" "$status | $output"
+        fi
+    }
+    queue_test test_sv_clone_rejects_missing_arg
+
+    # Test that sv-clone --help works.
+    test_sv_clone_help() {
+        local output
+        local status
+
+        set +e
+        output=$(sv_clone_cmd --help 2>&1)
+        status=$?
+        set -e
+
+        if [[ "$status" -eq 0 && "$output" == *"Usage:"* ]]; then
+            pass "sv-clone --help shows usage"
+        else
+            fail "sv-clone --help shows usage" "exit 0 with Usage" "$status | $output"
+        fi
+    }
+    queue_test test_sv_clone_help
+
+    fi # end sv-clone tests (non-SSH only)
+
+    ###############################################################################
     # Shell Args Tests
     ###############################################################################
 

--- a/scripts/tests
+++ b/scripts/tests
@@ -7,6 +7,9 @@ START_TIME=$(date +%s.%N)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SV_BASE="$SCRIPT_DIR/../sv"
 
+# Prevent user's SANDVAULT_ARGS from interfering with test expectations.
+unset SANDVAULT_ARGS
+
 # Each user on the computer can have their own sandvault.
 # Inside sandvault, USER will be sandvault-<name>, where name is the host-users's name.
 if [[ "$USER" == sandvault-* ]]; then

--- a/scripts/tests
+++ b/scripts/tests
@@ -549,161 +549,23 @@ run_tests() {
     }
     queue_test test_readable_dir_used
 
-    # Test cloning local repository into sandvault home and wiring remotes.
-    test_repository_clone_local() {
-        local src_repository
-        local clone_name
-        local clone_path
-        local output
-        local status
-        local host_origin
-        local remote_output
-        local expected_upstream
-
-        src_repository="$(git -C "$SCRIPT_DIR/.." rev-parse --show-toplevel 2>/dev/null || true)"
-        if [[ -z "$src_repository" || ! -d "$src_repository/.git" ]]; then
-            fail "--clone clones local repository into sandvault home" "current repository available" "$src_repository"
-            return
-        fi
-
-        clone_name="$(basename "$src_repository")"
-        clone_path="$SANDVAULT_HOME/repositories/$clone_name"
-        expected_upstream="$(git -C "$src_repository" remote get-url origin 2>/dev/null || true)"
-        if [[ -z "$expected_upstream" ]]; then
-            fail "--clone clones local repository into sandvault home" "source repository has origin remote" "$src_repository"
-            return
-        fi
-
-        set +e
-        output=$(sv_cmd s --clone "$src_repository" -- pwd 2>&1)
-        status=$?
-        set -e
-        if [[ "$status" -ne 0 ]]; then
-            fail "--clone clones local repository into sandvault home" "exit 0" "$status | $output"
-            return
-        fi
-
-        if [[ "$output" != *"$clone_path"* ]]; then
-            fail "--clone clones local repository into sandvault home" "$clone_path" "$output"
-            return
-        fi
-
-        host_origin="$(git -C "$src_repository" remote get-url origin 2>/dev/null)"
-        if [[ "$host_origin" != "$expected_upstream" ]]; then
-            fail "local repository keeps origin at upstream" "$expected_upstream" "$host_origin"
-            return
-        fi
-
-        remote_output="$(git -C "$src_repository" remote get-url sandvault 2>/dev/null)"
-        if [[ "$remote_output" != "$clone_path" ]]; then
-            fail "local repository gets sandvault remote" "$clone_path" "$remote_output"
-            return
-        fi
-
-        set +e
-        remote_output=$(sv_cmd s -- git -C "$clone_path" remote get-url origin 2>&1)
-        status=$?
-        set -e
-        if [[ "$status" -ne 0 || "$remote_output" != *"$expected_upstream"* ]]; then
-            fail "sandvault clone origin points to upstream" "$expected_upstream" "$status | $remote_output"
-            return
-        fi
-
-        set +e
-        remote_output=$(sv_cmd s -- git -C "$clone_path" remote get-url host-local 2>&1)
-        status=$?
-        set -e
-        if [[ "$status" -eq 0 ]]; then
-            fail "sandvault clone should not have host-local remote" "non-zero exit" "$status | $remote_output"
-            return
-        fi
-
-        set +e
-        remote_output=$(sv_cmd s -- git -C "$clone_path" remote get-url host-upstream 2>&1)
-        status=$?
-        set -e
-        if [[ "$status" -eq 0 ]]; then
-            fail "sandvault clone should not have host-upstream remote" "non-zero exit" "$status | $remote_output"
-            return
-        fi
-
-        pass "--clone clones local repository into sandvault home"
-
-        sv_cmd s -- rm -rf "$clone_path" >/dev/null 2>&1
-    }
-
-    # Test cloning HTTPS repository into sandvault home.
-    test_repository_clone_https() {
-        local clone_path
-        local output
-        local status
-        local remote_output
-        local https_repository
-
-        https_repository="https://github.com/webcoyote/sandvault.git"
-        clone_path="$SANDVAULT_HOME/repositories/sandvault"
-
-        # Start clean to avoid stale clone state influencing assertions.
-        sv_cmd s -- rm -rf "$clone_path" >/dev/null 2>&1
-
-        set +e
-        output=$(sv_cmd s --clone "$https_repository" -- pwd 2>&1)
-        status=$?
-        set -e
-        if [[ "$status" -ne 0 ]]; then
-            fail "--clone clones HTTPS repository into sandvault home" "exit 0" "$status | $output"
-            return
-        fi
-
-        if [[ "$output" != *"$clone_path"* ]]; then
-            fail "--clone clones HTTPS repository into sandvault home" "$clone_path" "$output"
-            return
-        fi
-
-        set +e
-        # Use "git config remote.origin.url" instead of
-        # "git remote get-url" to avoid issues with
-        # git url remapping with insteadOf override.
-        remote_output=$(sv_cmd s -- git -C "$clone_path" config remote.origin.url 2>&1)
-        status=$?
-        set -e
-        if [[ "$status" -ne 0 || "$remote_output" != *"$https_repository"* ]]; then
-            fail "sandvault HTTPS clone origin points to remote URL" "$https_repository" "$status | $remote_output"
-            return
-        fi
-
-        pass "--clone clones HTTPS repository into sandvault home"
-        sv_cmd s -- rm -rf "$clone_path" >/dev/null 2>&1
-    }
-
-    # Repository clone tests are intentionally skipped in SSH mode.
-    if [[ "$mode_label" == *" --ssh" ]]; then
-        :
-    else
-        queue_test test_repository_clone_local
-        # Clone tests share the same destination repo name (`sandvault`) and race if parallelized.
-        wait_for_all_running_tests
-        queue_test test_repository_clone_https
-    fi
-
-    # Test invalid --clone paths are rejected and require a path with a directory name.
-    test_repository_clone_reject_invalid_paths() {
+    # Test that --clone aborts with a message directing users to sv-clone.
+    test_clone_flag_rejected() {
         local output
         local status
 
         set +e
-        output=$(sv_cmd s --clone / -- pwd 2>&1)
+        output=$(sv_cmd s --clone https://example.com/repo.git 2>&1)
         status=$?
         set -e
 
-        if [[ "$status" -eq 0 || "$output" != *"--clone path must include a directory name"* ]]; then
-            fail "shell --clone / is rejected" "non-zero exit and path-with-directory-name message" "$status | $output"
-            return
+        if [[ "$status" -ne 0 && "$output" == *"sv-clone"* ]]; then
+            pass "--clone aborts with sv-clone migration message"
+        else
+            fail "--clone aborts with sv-clone migration message" "non-zero exit mentioning sv-clone" "$status | $output"
         fi
-
-        pass "invalid --clone paths are rejected"
     }
-    queue_test test_repository_clone_reject_invalid_paths
+    queue_test test_clone_flag_rejected
 
     ###############################################################################
     # Shell Args Tests

--- a/scripts/tests
+++ b/scripts/tests
@@ -284,6 +284,19 @@ run_tests() {
     }
     queue_test test_version
 
+    # Verify SANDVAULT_ARGS is not leaking into test runs.
+    # The unset at the top of this script should have cleared any inherited value.
+    # If that guard is removed, a user's SANDVAULT_ARGS (e.g. --verbose --ssh)
+    # would inject unexpected flags into every sv invocation.
+    test_sandvault_args_ignored() {
+        if [[ -z "${SANDVAULT_ARGS+set}" ]]; then
+            pass "SANDVAULT_ARGS does not leak into tests"
+        else
+            fail "SANDVAULT_ARGS does not leak into tests" "unset" "SANDVAULT_ARGS='$SANDVAULT_ARGS'"
+        fi
+    }
+    queue_test test_sandvault_args_ignored
+
     # --help
     test_help() {
         local output

--- a/scripts/tests
+++ b/scripts/tests
@@ -297,6 +297,22 @@ run_tests() {
     }
     queue_test test_sandvault_args_ignored
 
+    # Verify SANDVAULT_ARGS is honored by sv when set.
+    test_sandvault_args_version() {
+        local output
+        local status
+        set +e
+        output=$(SANDVAULT_ARGS="--version" "$bash_path" "$SV_BASE" shell 2>&1)
+        status=$?
+        set -e
+        if [[ "$status" -eq 0 && "$output" == *"version"* ]]; then
+            pass "SANDVAULT_ARGS=--version prints version"
+        else
+            fail "SANDVAULT_ARGS=--version prints version" "exit 0 with version output" "$status | $output"
+        fi
+    }
+    queue_test test_sandvault_args_version
+
     # --help
     test_help() {
         local output

--- a/sv
+++ b/sv
@@ -400,28 +400,6 @@ install_ios_deps() {
     fi
 }
 
-init_sandbox_run_for_repository() {
-    SANDBOX_RUN=()
-    if [[ "$NESTED" == "false" ]]; then
-        SANDBOX_RUN+=("sudo" "--non-interactive" "--user=$SANDVAULT_USER")
-    fi
-    SANDBOX_RUN+=(
-        "/usr/bin/env" "-i"
-        "HOME=/Users/$SANDVAULT_USER"
-        "USER=$SANDVAULT_USER"
-        "SHELL=/bin/zsh"
-        "PATH=/usr/bin:/bin:/usr/sbin:/sbin"
-    )
-}
-
-sandbox_repository_git() {
-    "${SANDBOX_RUN[@]}" git -C "$INITIAL_DIR" "$@"
-}
-
-local_repository_git() {
-    git -C "$LOCAL_REPOSITORY" "$@"
-}
-
 force_cleanup_sandvault_processes() {
     local cleanup_mode="${1:-session-exit}"
     if [[ "$NESTED" == "true" ]]; then
@@ -804,8 +782,6 @@ NATIVE_INSTALL=false
 MODE=shell
 COMMAND_ARGS=()
 INITIAL_DIR=""
-CLONE_REPOSITORY=""
-
 show_help() {
     echo "SandVault $VERSION by Patrick Wyatt <pat@codeofhonor.com>"
     echo "Project home page: https://github.com/webcoyote/sandvault"
@@ -827,7 +803,7 @@ show_help() {
     echo "  -e, --endpoint       Show Chrome endpoint URL (requires --browser session)"
     echo "  -i, --ios            Boot iOS Simulator and expose HTTP bridge into sandbox"
     echo "  -I, --ios-gui        Also show the Simulator.app window (implies --ios)"
-    echo "  -c, --clone URL|PATH Clone Git repository into sandvault home and open there"
+    echo "  -c, --clone URL|PATH (removed — use sv-clone instead)"
     echo "  -N, --native-install Use native installers instead of Homebrew for AI tools"
     echo "  --fix-permissions    Fix umask and file permissions [standalone or with build]"
     echo "  --version            Show version information"
@@ -922,11 +898,7 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         -c|--clone)
-            if [[ $# -lt 2 ]]; then
-                abort "Missing argument for $1"
-            fi
-            CLONE_REPOSITORY="$2"
-            shift 2
+            abort "--clone has been removed from sv. Use sv-clone instead:\n  sv-clone <URL|PATH> [-- sv-args ...]"
             ;;
         -h|--help)
             show_help
@@ -994,20 +966,14 @@ case "${1:-}" in
         ;;
 esac
 readonly COMMAND
-readonly CLONE_REPOSITORY
 
 if [[ "$FIX_PERMISSIONS" == "true" && "$COMMAND" != "build" ]]; then
     abort "--fix-permissions can only be used standalone or with build"
 fi
 
-if [[ -z "$CLONE_REPOSITORY" ]]; then
-    # Resolve symlinks to get the real path
-    INITIAL_DIR="$(cd "${INITIAL_DIR:-"${PWD}"}" 2>/dev/null && pwd -P || echo "$INITIAL_DIR")"
-    readonly INITIAL_DIR
-elif [[ -n "$INITIAL_DIR" ]]; then
-    # --clone wants to set INITIAL_DIRECTORY
-    abort "Cannot use [PATH] and --clone together; choose one"
-fi
+# Resolve symlinks to get the real path
+INITIAL_DIR="$(cd "${INITIAL_DIR:-"${PWD}"}" 2>/dev/null && pwd -P || echo "$INITIAL_DIR")"
+readonly INITIAL_DIR
 
 
 ###############################################################################
@@ -1508,124 +1474,6 @@ if [[ -d "$WORKSPACE/guest/home/user" ]]; then
     abort "Storing user configuration in 'guest/home/user/' is no longer supported. Move it to the shared workspace instead:\n\n  /usr/bin/rsync --archive --remove-source-files '$WORKSPACE/guest/home/user/' '$SHARED_WORKSPACE/user/' && rmdir '$WORKSPACE/guest/home/user'"
 fi
 
-
-###############################################################################
-# Run the application
-###############################################################################
-if [[ -n "$CLONE_REPOSITORY" ]]; then
-    CLONE_SUPPORTED_COMMANDS=(shell claude codex opencode gemini)
-    for supported_command in "${CLONE_SUPPORTED_COMMANDS[@]}"; do
-        if [[ "${COMMAND:-shell}" == "$supported_command" ]]; then
-            break
-        fi
-    done
-    if [[ "${COMMAND:-shell}" != "${supported_command:-}" ]]; then
-        abort "--clone is only supported with: ${CLONE_SUPPORTED_COMMANDS[*]}"
-    fi
-
-    case "$(basename "${CLONE_REPOSITORY%/}")" in
-        ""|/)
-            abort "--clone path must include a directory name"
-            ;;
-        *)
-            :
-            ;;
-    esac
-
-    init_sandbox_run_for_repository
-
-    if [[ -d "$CLONE_REPOSITORY" ]]; then
-        LOCAL_REPOSITORY="$(cd "$CLONE_REPOSITORY" && pwd -P)"
-        REPOSITORY_SOURCE_URL="$(local_repository_git remote get-url origin)"
-        REPOSITORY_CLONE_SOURCE="$LOCAL_REPOSITORY"
-        REPOSITORY_NAME="$(basename "$LOCAL_REPOSITORY")"
-    else
-        REPOSITORY_SOURCE_URL="$CLONE_REPOSITORY"
-        REPOSITORY_CLONE_SOURCE="$REPOSITORY_SOURCE_URL"
-        REPOSITORY_NAME="${REPOSITORY_SOURCE_URL%/}"
-    fi
-
-    [[ "$REPOSITORY_NAME" == *"://"* ]] && REPOSITORY_NAME="${REPOSITORY_NAME##*/}"
-    if [[ "$REPOSITORY_NAME" == *:* ]]; then
-        REPOSITORY_NAME="${REPOSITORY_NAME##*:}"
-    fi
-    REPOSITORY_NAME="${REPOSITORY_NAME##*/}"
-    REPOSITORY_NAME="${REPOSITORY_NAME%.git}"
-    if [[ -z "$REPOSITORY_NAME" ]]; then
-        abort "Could not determine repository name from --clone argument"
-    fi
-
-    INITIAL_DIR="/Users/$SANDVAULT_USER/repositories/$REPOSITORY_NAME"
-
-    USE_DIRECT_LOCAL_CLONE=false
-    LOCAL_GIT_SAFE_DIRECTORY_ARGS=()
-    if [[ -n "${LOCAL_REPOSITORY:-}" ]]; then
-        LOCAL_GIT_SAFE_DIRECTORY_ARGS=(
-            -c "safe.directory=$LOCAL_REPOSITORY"
-            -c "safe.directory=$LOCAL_REPOSITORY/.git"
-        )
-        # Ensure sandvault user can read repository metadata before direct clone/fetch
-        if "${SANDBOX_RUN[@]}" test -r "$LOCAL_REPOSITORY" \
-            && "${SANDBOX_RUN[@]}" git \
-                "${LOCAL_GIT_SAFE_DIRECTORY_ARGS[@]}" \
-                -C "$LOCAL_REPOSITORY" rev-parse --git-dir &>/dev/null; then
-            USE_DIRECT_LOCAL_CLONE=true
-        fi
-    fi
-    # Clone into a directory writable by user and readable by sandvault-user
-    (
-        # Use directory that both $USER and sandvault-$USER find valid
-        cd "$SHARED_WORKSPACE"
-        "${SANDBOX_RUN[@]}" mkdir -p "$(dirname "$INITIAL_DIR")"
-
-        if [[ "$USE_DIRECT_LOCAL_CLONE" == "true" ]]; then
-            if ! "${SANDBOX_RUN[@]}" test -d "$INITIAL_DIR/.git"; then
-                "${SANDBOX_RUN[@]}" git \
-                    "${LOCAL_GIT_SAFE_DIRECTORY_ARGS[@]}" \
-                    clone --no-hardlinks "$LOCAL_REPOSITORY" "$INITIAL_DIR"
-            else
-                "${SANDBOX_RUN[@]}" git \
-                    "${LOCAL_GIT_SAFE_DIRECTORY_ARGS[@]}" \
-                    -C "$INITIAL_DIR" fetch "$LOCAL_REPOSITORY"
-            fi
-        else
-            mkdir -p "$SHARED_WORKSPACE/tmp"
-            HOST_SOURCE_DIR="$(mktemp -d "$SHARED_WORKSPACE/tmp/sv-clone-$REPOSITORY_NAME.XXXXXX")"
-            trap '
-                cd "$SHARED_WORKSPACE"
-                "${SANDBOX_RUN[@]}" git config --global --unset-all --fixed-value safe.directory "$HOST_SOURCE_DIR" || true
-                "${SANDBOX_RUN[@]}" git config --global --unset-all --fixed-value safe.directory "$HOST_SOURCE_DIR/.git" || true
-                rm -rf "$HOST_SOURCE_DIR"
-            ' EXIT
-            "${SANDBOX_RUN[@]}" git config --global --add safe.directory "$HOST_SOURCE_DIR"
-            "${SANDBOX_RUN[@]}" git config --global --add safe.directory "$HOST_SOURCE_DIR/.git"
-
-            # Clone the repo in a way that sandvault-user has access to all files (--no-hardlinks)
-            git clone --mirror --no-hardlinks "$REPOSITORY_CLONE_SOURCE" "$HOST_SOURCE_DIR"
-            chmod -R a+rX "$HOST_SOURCE_DIR" 2>/dev/null || warn "Could not set permissions on cloned repository ($HOST_SOURCE_DIR). The sandvault user may not be able to read it."
-            if ! "${SANDBOX_RUN[@]}" test -d "$INITIAL_DIR/.git"; then
-                "${SANDBOX_RUN[@]}" git clone "$HOST_SOURCE_DIR" "$INITIAL_DIR"
-            else
-                "${SANDBOX_RUN[@]}" git -C "$INITIAL_DIR" fetch "$HOST_SOURCE_DIR"
-            fi
-        fi
-    )
-
-    if "${SANDBOX_RUN[@]}" git -C "$INITIAL_DIR" remote get-url origin &>/dev/null; then
-        sandbox_repository_git remote set-url origin "$REPOSITORY_SOURCE_URL"
-    else
-        sandbox_repository_git remote add origin "$REPOSITORY_SOURCE_URL"
-    fi
-
-    if [[ -n "${LOCAL_REPOSITORY:-}" ]]; then
-        if git -C "$LOCAL_REPOSITORY" remote get-url sandvault &>/dev/null; then
-            local_repository_git remote set-url sandvault "$INITIAL_DIR"
-        else
-            local_repository_git remote add sandvault "$INITIAL_DIR"
-        fi
-    fi
-fi
-readonly INITIAL_DIR
 
 ###############################################################################
 # Fix permissions (runs with --fix-permissions regardless of --rebuild)

--- a/sv-clone
+++ b/sv-clone
@@ -193,7 +193,7 @@ if [[ -d "$REPO_DIR/.git" ]]; then
 else
     debug "Cloning into $REPO_DIR..."
     mkdir -p "$(dirname "$REPO_DIR")"
-    git clone "$CLONE_SOURCE" "$REPO_DIR"
+    git clone --no-hardlinks "$CLONE_SOURCE" "$REPO_DIR"
 
     # If cloned from a local path, set origin to the real remote URL
     if [[ -n "$LOCAL_REPOSITORY" ]]; then

--- a/sv-clone
+++ b/sv-clone
@@ -1,0 +1,228 @@
+#!/bin/bash
+# Clone a git repository into the sandvault shared workspace.
+#
+# This script runs as $USER (the host user), which has full permissions to
+# read local repositories and clone from remote URLs. The clone destination
+# is $SHARED_WORKSPACE/repos/<name>, which is accessible to both the host
+# user and the sandvault user via group ACLs.
+#
+# After cloning, it launches an sv session in the cloned repository.
+#
+# Usage:
+#   sv-clone [-v|-vv|-vvv] <URL|PATH> [-- sv-args ...]
+#
+# Everything after -- is passed directly to sv (options, command, args).
+# If no command is given, defaults to "shell".
+#
+# Examples:
+#   sv-clone https://github.com/org/repo.git
+#   sv-clone git@github.com:org/repo.git -- claude
+#   sv-clone ~/projects/myrepo -- -b shell -- echo hello
+set -Eeuo pipefail
+trap 'echo "${BASH_SOURCE[0]}: line $LINENO: $BASH_COMMAND: exitcode $?"' ERR
+
+# Resolve script location
+SOURCE="${BASH_SOURCE[0]}"
+while [[ -L "$SOURCE" ]]; do
+    SOURCE_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd -P)"
+    SOURCE="$(readlink "$SOURCE")"
+    [[ "$SOURCE" = /* ]] || SOURCE="$SOURCE_DIR/$SOURCE"
+done
+SCRIPT_DIR="$(cd -P "$(dirname "$SOURCE")" && pwd -P)"
+WORKSPACE="$SCRIPT_DIR"
+
+# If running from a Homebrew Cellar, use the stable opt/ symlink
+if [[ "$WORKSPACE" =~ ^(.*)/homebrew/Cellar/([^/]+)/[^/]+$ ]]; then
+    WORKSPACE="${BASH_REMATCH[1]}/homebrew/opt/${BASH_REMATCH[2]}"
+fi
+
+SV="$WORKSPACE/sv"
+if [[ ! -x "$SV" ]]; then
+    echo >&2 "ERROR: sv not found at $SV"
+    exit 1
+fi
+
+
+###############################################################################
+# Functions
+###############################################################################
+[[ "${SV_VERBOSE:-0}" =~ ^[0-9]+$ ]] && SV_VERBOSE="${SV_VERBOSE:-0}" || SV_VERBOSE=1
+trace () {
+    [[ "$SV_VERBOSE" -lt 2 ]] || echo >&2 -e "🔬 \033[90m$*\033[0m"
+}
+debug () {
+    [[ "$SV_VERBOSE" -lt 1 ]] || echo >&2 -e "🔍 \033[36m$*\033[0m"
+}
+info () {
+    echo >&2 -e "ℹ️  \033[36m$*\033[0m"
+}
+warn () {
+    echo >&2 -e "⚠️  \033[33m$*\033[0m"
+}
+error () {
+    echo >&2 -e "❌ \033[31m$*\033[0m"
+}
+abort () {
+    error "$*"
+    exit 1
+}
+
+
+###############################################################################
+# Parse command line
+###############################################################################
+CLONE_REPOSITORY=""
+SV_ARGS=()
+
+if [[ $# -lt 1 ]]; then
+    echo >&2 "Usage: $(basename "$0") [OPTIONS] <URL|PATH> [-- sv-args ...]"
+    exit 1
+fi
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --)
+            shift
+            SV_ARGS=("$@")
+            break
+            ;;
+        -v|--verbose)
+            ((SV_VERBOSE++)) || true
+            shift
+            ;;
+        -vv)
+            ((SV_VERBOSE+=2)) || true
+            shift
+            ;;
+        -vvv)
+            ((SV_VERBOSE+=3)) || true
+            shift
+            ;;
+        -h|--help)
+            echo "Usage: $(basename "$0") [-v|-vv|-vvv] <URL|PATH> [-- sv-args ...]"
+            echo ""
+            echo "Clone a git repository into the sandvault shared workspace and"
+            echo "launch an sv session there."
+            echo ""
+            echo "Options:"
+            echo "  -v, --verbose   Enable verbose output"
+    echo "  -vv / -vvv      More verbose / even more verbose"
+            echo "  -h, --help      Show this help message"
+            echo ""
+            echo "Everything after -- is passed directly to sv."
+            echo "If no sv command is given, defaults to 'shell'."
+            exit 0
+            ;;
+        -*)
+            abort "Unknown option: $1"
+            ;;
+        *)
+            if [[ -z "$CLONE_REPOSITORY" ]]; then
+                CLONE_REPOSITORY="$1"
+                shift
+            else
+                abort "Unexpected argument: $1 (use -- to pass arguments to sv)"
+            fi
+            ;;
+    esac
+done
+
+if [[ -z "$CLONE_REPOSITORY" ]]; then
+    abort "Missing repository URL or path"
+fi
+
+
+###############################################################################
+# Determine user and workspace paths
+###############################################################################
+if [[ "$USER" == sandvault-* ]]; then
+    HOST_USER="${USER#sandvault-}"
+else
+    HOST_USER="$USER"
+fi
+readonly HOST_USER
+readonly SHARED_WORKSPACE="/Users/Shared/sv-$HOST_USER"
+
+if [[ ! -d "$SHARED_WORKSPACE" ]]; then
+    abort "Shared workspace not found: $SHARED_WORKSPACE (run 'sv build' first)"
+fi
+
+
+###############################################################################
+# Resolve repository name and source URL
+###############################################################################
+LOCAL_REPOSITORY=""
+if [[ -d "$CLONE_REPOSITORY" ]]; then
+    LOCAL_REPOSITORY="$(cd "$CLONE_REPOSITORY" && pwd -P)"
+    REPOSITORY_SOURCE_URL="$(git -C "$LOCAL_REPOSITORY" remote get-url origin 2>/dev/null)" \
+        || abort "Local repository $LOCAL_REPOSITORY has no 'origin' remote"
+    REPOSITORY_NAME="$(basename "$LOCAL_REPOSITORY")"
+else
+    REPOSITORY_SOURCE_URL="$CLONE_REPOSITORY"
+    REPOSITORY_NAME="${REPOSITORY_SOURCE_URL%/}"
+fi
+
+# Extract bare repository name from URL
+[[ "$REPOSITORY_NAME" == *"://"* ]] && REPOSITORY_NAME="${REPOSITORY_NAME##*/}"
+if [[ "$REPOSITORY_NAME" == *:* ]]; then
+    REPOSITORY_NAME="${REPOSITORY_NAME##*:}"
+fi
+REPOSITORY_NAME="${REPOSITORY_NAME##*/}"
+REPOSITORY_NAME="${REPOSITORY_NAME%.git}"
+if [[ -z "$REPOSITORY_NAME" ]]; then
+    abort "Could not determine repository name from: $CLONE_REPOSITORY"
+fi
+
+readonly REPOSITORY_NAME
+readonly REPOSITORY_SOURCE_URL
+readonly CLONE_SOURCE="${LOCAL_REPOSITORY:-$REPOSITORY_SOURCE_URL}"
+readonly REPO_DIR="$SHARED_WORKSPACE/repos/$REPOSITORY_NAME"
+
+debug "Repository: $REPOSITORY_NAME"
+debug "Source URL: $REPOSITORY_SOURCE_URL"
+debug "Clone from: $CLONE_SOURCE"
+debug "Destination: $REPO_DIR"
+
+
+###############################################################################
+# Clone or fetch
+###############################################################################
+if [[ -d "$REPO_DIR/.git" ]]; then
+    debug "Repository already exists; fetching..."
+    git -C "$REPO_DIR" fetch "${LOCAL_REPOSITORY:-origin}"
+else
+    debug "Cloning into $REPO_DIR..."
+    mkdir -p "$(dirname "$REPO_DIR")"
+    git clone "$CLONE_SOURCE" "$REPO_DIR"
+
+    # If cloned from a local path, set origin to the real remote URL
+    if [[ -n "$LOCAL_REPOSITORY" ]]; then
+        git -C "$REPO_DIR" remote set-url origin "$REPOSITORY_SOURCE_URL"
+    fi
+fi
+info "Repository ready at $REPO_DIR"
+
+
+###############################################################################
+# Add sandvault remote to local repository (if cloning from local)
+###############################################################################
+if [[ -n "$LOCAL_REPOSITORY" ]]; then
+    if git -C "$LOCAL_REPOSITORY" remote get-url sandvault &>/dev/null; then
+        git -C "$LOCAL_REPOSITORY" remote set-url sandvault "$REPO_DIR"
+    else
+        git -C "$LOCAL_REPOSITORY" remote add sandvault "$REPO_DIR"
+    fi
+    debug "Added 'sandvault' remote to $LOCAL_REPOSITORY"
+fi
+
+
+###############################################################################
+# Launch sandvault session in the cloned repository
+###############################################################################
+# Default to "shell" if no sv args were given
+if [[ ${#SV_ARGS[@]} -eq 0 ]]; then
+    SV_ARGS=("shell")
+fi
+
+info "Starting sandvault in $REPO_DIR..."
+exec "$SV" "${SV_ARGS[@]}" "$REPO_DIR"

--- a/tests/tests
+++ b/tests/tests
@@ -7,6 +7,9 @@ START_TIME=$(date +%s.%N)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 cd "$SCRIPT_DIR"
 
+# Prevent user's SANDVAULT_ARGS from interfering with test expectations.
+unset SANDVAULT_ARGS
+
 [[ "${VERBOSE:-0}" =~ ^[0-9]+$ ]] && VERBOSE="${VERBOSE:-0}" || VERBOSE=1
 
 # We want to run the tests inside sandvault. However, sandvault


### PR DESCRIPTION
The repository cloning capability is useful but not core to `sv`. This PR proposes moving that functionality into a separate script that performs the clone, then delegates all other arguments to the original `sv` script.


old way: `sv shell --clone https://github.com/FOO/BAR`
new way: `sv-clone https://github.com/FOO/BAR`

old way: `sv claude --clone https://github.com/FOO/BAR`
new way: `sv-clone https://github.com/FOO/BAR -- claude`



The `sv-clone` script has a slight difference from `sv --clone` that I want to point out: instead of cloning into `/Users/sandvault-$USER/repositories` (AKA $SANDVAULT_HOME), it clones into /Users/Shared/sv-$USER/repos` (AKA $SHARED_WORKSPACE).

Why?

The shared workspace folder is writable to both $USER and sandvault-$USER, so no special measures are required to clone the repo as there are for sandvault home directory, which sometimes takes two copies.

If this is undesirable for some reason, I can modify this PR to keep the original location using the 1-or-2-copies method that `sv` presently uses.

There's another reason to make this change; this PR (https://github.com/webcoyote/sandvault/pull/130) enables sandvault-cloned repositories to have per-repo deploy keys. It's another large chunk of code that is unrelated to "core sv behavior", but would fit nicely into this standalone `sv-clone` script.

What do you think @MikeMcQuaid?

