### PR TITLE
Add /sv Claude Code skill for handing off tasks to sandvault

### DIFF
--- a/skills/sandvault/sv/SKILL.md
+++ b/skills/sandvault/sv/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: sv
+description: This skill should be used when the user invokes `/sv` or asks to "hand this off to sandvault", "continue in the sandbox", "sandvault this task", or to clone the current repo into a sandboxed Claude session with per-repo deploy-key access. Writes a task briefing to the sandvault shared workspace and launches `sv-clone` in a new terminal window, pointing the sandboxed Claude at the briefing as its first prompt.
+---
+
+# Sandvault Handoff
+
+Hand off the current task to a sandboxed Claude running inside sandvault.
+
+## When to use
+
+The user invokes `/sv` when they want Claude to continue the current work inside a sandvault sandbox.
+
+## Steps
+
+### 1. Summarize the task
+
+Write a clear, actionable summary of what the user wants done. Include:
+- What the goal is
+- What approach to take (if already discussed)
+- What files are involved
+- Any decisions already made in this conversation
+- The current branch name and any relevant context
+
+### 2. Write the handoff file
+
+Write the task briefing to `/Users/Shared/sv-$USER/handoff-<repo>.md`,
+where `$USER` is the host user and `<repo>` is the source repo's
+basename (e.g. `/Users/Shared/sv-jesse/handoff-sandvault.md`). This is
+the sandvault shared workspace — readable from inside the sandbox via
+the mounted `/Users/Shared` tree, so the sandboxed Claude can read it
+at startup. The briefing is **not** copied into the clone; it lives in
+the shared workspace and the sandboxed Claude is pointed at it by path
+(see step 4). Nothing is written into the source repo itself.
+
+The handoff file should include:
+- A "# Task Handoff" heading
+- Task context, approach, decisions, branch, relevant files
+- A "## Setup" section: note that gitignored build artifacts (`.venv/`, `node_modules/`, build dirs) won't be in the clone. Check for `requirements.txt`, `pyproject.toml`, `package.json` etc. and instruct the sandboxed Claude to set up the environment first.
+- A "## What to do" section with a direct instruction
+
+### 3. Ask the user for confirmation
+
+Show the user:
+- The repo that will be cloned
+- A brief summary of the task being handed off
+
+### 4. Launch in a new terminal window
+
+Detect the user's default terminal and launch `sv-clone` in a new window.
+
+**Detect the default terminal:**
+
+```bash
+defaults read com.apple.LaunchServices/com.apple.launchservices.secure LSHandlers 2>/dev/null | grep -A1 "LSHandlerRoleShell" | grep -o '"[^"]*"' | tr -d '"'
+```
+
+Look for `com.googlecode.iterm2` (iTerm2) or `com.apple.Terminal` (Terminal.app). If detection fails, default to Terminal.app.
+
+The launch command runs `sv-clone`, passing the handoff path to the
+sandboxed Claude as its initial prompt via the `--` separator
+pass-through (`sv-clone` → `sv` → sandbox zshrc → `claude`):
+
+```
+sv-clone <repo-path> -- claude -- "Read /Users/Shared/sv-<host-user>/handoff-<repo>.md and continue the task described there."
+```
+
+Substitute `<host-user>` (the host user's login — same `$USER` used
+when writing the handoff file) and `<repo>` (the source repo's
+basename) literally into the prompt string.
+
+If `sv-clone` is not on PATH, the installed sandvault is out of date — tell the user to upgrade (e.g. `brew upgrade sandvault`) and retry. The old `sv --clone` flag has been removed in favor of the standalone `sv-clone` script.
+
+**For iTerm2:**
+
+```bash
+osascript <<'EOF'
+tell application "iTerm2"
+    activate
+    set newWindow to (create window with default profile)
+    tell current session of newWindow
+        write text "sv-clone <repo-path> -- claude -- \"Read /Users/Shared/sv-<host-user>/handoff-<repo>.md and continue the task described there.\""
+    end tell
+end tell
+EOF
+```
+
+**For Terminal.app:**
+
+```bash
+osascript -e 'tell application "Terminal" to activate' -e 'tell application "Terminal" to do script "sv-clone <repo-path> -- claude -- \"Read /Users/Shared/sv-<host-user>/handoff-<repo>.md and continue the task described there.\""'
+```

--- a/sv
+++ b/sv
@@ -1522,6 +1522,19 @@ if [[ "$FIX_PERMISSIONS" == "true" ]]; then
     debug "Permissions check complete"
 fi
 
+# Install the Claude Code /sv skill when Claude Code is present. The skill
+# lives under the sandvault namespace (~/.claude/skills/sandvault/sv) so it
+# won't collide with any other skill named "sv". Use /bin/ln explicitly —
+# GNU coreutils `ln` on PATH (e.g. via Homebrew) has incompatible flag
+# handling that has bitten this project before.
+CLAUDE_SKILLS_ROOT="$HOME/.claude/skills/sandvault"
+SV_SKILL_SOURCE="$WORKSPACE/skills/sandvault/sv"
+if [[ -d "$HOME/.claude" && -d "$SV_SKILL_SOURCE" ]]; then
+    mkdir -p "$CLAUDE_SKILLS_ROOT"
+    /bin/ln -sfn "$SV_SKILL_SOURCE" "$CLAUDE_SKILLS_ROOT/sv"
+    debug "Installed /sv skill symlink at $CLAUDE_SKILLS_ROOT/sv"
+fi
+
 if [[ "$COMMAND" == "build" ]]; then
     exit 0
 fi

--- a/sv
+++ b/sv
@@ -1523,16 +1523,16 @@ if [[ "$FIX_PERMISSIONS" == "true" ]]; then
 fi
 
 # Install the Claude Code /sv skill when Claude Code is present. The skill
-# lives under the sandvault namespace (~/.claude/skills/sandvault/sv) so it
+# lives under the sandvault namespace (~/.claude/skills/sandvault) so it
 # won't collide with any other skill named "sv". Use /bin/ln explicitly —
 # GNU coreutils `ln` on PATH (e.g. via Homebrew) has incompatible flag
 # handling that has bitten this project before.
-CLAUDE_SKILLS_ROOT="$HOME/.claude/skills/sandvault"
-SV_SKILL_SOURCE="$WORKSPACE/skills/sandvault/sv"
-if [[ -d "$HOME/.claude" && -d "$SV_SKILL_SOURCE" ]]; then
-    mkdir -p "$CLAUDE_SKILLS_ROOT"
-    /bin/ln -sfn "$SV_SKILL_SOURCE" "$CLAUDE_SKILLS_ROOT/sv"
-    debug "Installed /sv skill symlink at $CLAUDE_SKILLS_ROOT/sv"
+SV_SKILL_SOURCE="$WORKSPACE/skills/sandvault/sv/SKILL.md"
+SV_SKILL_DEST="$HOME/.claude/skills/sandvault/SKILL.md"
+if [[ ! -L "$SV_SKILL_DEST" ]]; then
+    mkdir -p "$(dirname "$SV_SKILL_DEST")"
+    /bin/ln -sfn "$SV_SKILL_SOURCE" "$SV_SKILL_DEST"
+    debug "Installed /sv skill symlink at $SV_SKILL_DEST"
 fi
 
 if [[ "$COMMAND" == "build" ]]; then


### PR DESCRIPTION
I think this is useful enough to try as a real skill.

Replaces #136 (dev preview) with a shippable version. Adds a `/sv` Claude Code skill that hands the current task off to a sandboxed Claude: writes a task briefing to the sandvault shared workspace, then launches `sv-clone` in a new terminal window passing the briefing path to the sandboxed Claude as its first prompt. No files are written into the source repo.

I've deleted the fun animation — would be very happy to keep it fun if @webcoyote wants that!

Claude has generated / updated using the Anthropic creating-a-skill skill.

## Incorporated feedback from @webcoyote on #136

- Installed under `~/.claude/skills/sandvault/sv/` — skill namespaced so it won't collide with any other `/sv` skill.
- `sv build` uses `/bin/ln` explicitly (not `ln`) to avoid GNU coreutils flag incompatibilities.
- Install block collapsed to a single `ln -sfn` call — handles fresh install, re-install, and existing symlink uniformly.
- Dropped `sv-vibes.sh` (the cosmetic issues you noted; simplified to a single-file skill).
- `SKILL.md` no longer references the outdated `sv deploy-key` command — deploy keys are now auto-generated by `sv-clone` (merged in #139).

## Architectural change vs #136

The handoff mechanism moved. In #136, `sv-clone` injected `handoff.md` into the clone as `CLAUDE.md`. That never worked for local-path clones (`git clone --no-hardlinks` doesn't copy untracked files). This PR's skill writes the briefing to `/Users/Shared/sv-$USER/handoff-<repo>.md` in the shared workspace and passes the path to the sandboxed Claude as its first prompt:

```
sv-clone <repo> -- claude -- "Read /Users/Shared/sv-<user>/handoff-<repo>.md and continue the task described there."
```

No changes to `sv-clone` required — the handoff rides through existing `sv-clone → sv → sandbox zshrc → claude` arg forwarding.

## Note for existing /sv users

After upgrade, the old location (`~/.claude/skills/sv/`) is orphaned. Run once:

```
rm -rf ~/.claude/skills/sv
```

## Test plan

- [ ] `sv build` with Claude Code installed — symlink at `~/.claude/skills/sandvault/sv`
- [ ] `sv build` without Claude Code (`~/.claude/` missing) — no error, block skipped
- [ ] `sv build` a second time — symlink refreshed, no error
- [ ] `/sv` invoked from Claude Code — writes handoff file, opens new terminal, launches `sv-clone` with the briefing path as claude's first arg
- [ ] Sandboxed Claude reads the briefing and continues the task