### PR TITLE
Split ACLs for directories and files to prevent execute bit on files

### DIFF
--- a/sv
+++ b/sv
@@ -159,7 +159,8 @@ readonly HOST_USER
 readonly SANDVAULT_USER="sandvault-$HOST_USER"
 readonly SANDVAULT_GROUP="sandvault-$HOST_USER"
 readonly SHARED_WORKSPACE="/Users/Shared/sv-$HOST_USER"
-readonly SANDVAULT_RIGHTS="group:$SANDVAULT_GROUP allow read,write,append,delete,delete_child,readattr,writeattr,readextattr,writeextattr,readsecurity,writesecurity,chown,search,list,file_inherit,directory_inherit"
+readonly SANDVAULT_DIR_RIGHTS="group:$SANDVAULT_GROUP allow read,write,append,delete,delete_child,readattr,writeattr,readextattr,writeextattr,readsecurity,writesecurity,chown,search,list,file_inherit,directory_inherit"
+readonly SANDVAULT_FILE_RIGHTS="group:$SANDVAULT_GROUP allow read,write,append,delete,readattr,writeattr,readextattr,writeextattr,readsecurity,writesecurity,chown,file_inherit,directory_inherit"
 
 # Create sudoers.d file for passwordless sudo to sandvault user
 readonly SUDOERS_FILE="/etc/sudoers.d/50-nopasswd-for-$SANDVAULT_USER"
@@ -696,16 +697,36 @@ configure_shared_folder_permssions() {
         sudo /usr/sbin/chown -f -R "$HOST_USER:$SANDVAULT_GROUP" "$SHARED_WORKSPACE"
         trace "Configuring $SHARED_WORKSPACE permissions..."
         sudo /bin/chmod 0770 "$SHARED_WORKSPACE"
-        trace "Configuring $SHARED_WORKSPACE: add $SANDVAULT_RIGHTS (recursively)"
-        sudo find "$SHARED_WORKSPACE" -print0 | xargs -0 sudo /bin/chmod -h +a "$SANDVAULT_RIGHTS"
+        # Apply directory ACL (with search/list) to directories only,
+        # and file ACL (without search/list) to files only, so that
+        # files don't inherit the execute bit from the search permission.
+        # Single find pass to avoid walking the tree twice.
+        trace "Configuring $SHARED_WORKSPACE: add directory and file ACLs"
+        sudo find "$SHARED_WORKSPACE" \
+            \( -type d -exec /bin/chmod -h +a "$SANDVAULT_DIR_RIGHTS" {} + \) \
+            -o \
+            \( ! -type d -exec /bin/chmod -h +a "$SANDVAULT_FILE_RIGHTS" {} + \)
     else
         # Make workspace accessible to $HOST_USER only
         trace "Configuring $SHARED_WORKSPACE: restoring owner to $HOST_USER:$(id -gn)"
         sudo /usr/sbin/chown -f -R "$HOST_USER:$(id -gn)" "$SHARED_WORKSPACE"
         trace "Configuring $SHARED_WORKSPACE permissions..."
         sudo /bin/chmod 0700 "$SHARED_WORKSPACE"
-        trace "Configuring $SHARED_WORKSPACE: remove $SANDVAULT_RIGHTS (recursively)"
-        sudo find "$SHARED_WORKSPACE" -print0 2>/dev/null | xargs -0 sudo /bin/chmod -h -a "$SANDVAULT_RIGHTS" 2>/dev/null || true
+        # Remove all ACL entries for the sandvault group. Try removing
+        # both the old single-ACL format and the new split dir/file ACLs,
+        # plus the old combined ACL (from before the dir/file split).
+        # Each -a removal is a no-op (fails silently) if the ACE doesn't exist.
+        # Single find pass to avoid walking the tree three times.
+        trace "Configuring $SHARED_WORKSPACE: remove $SANDVAULT_GROUP ACLs"
+        local file_list
+        file_list=$(mktemp)
+        sudo find "$SHARED_WORKSPACE" -print0 2>/dev/null | sudo tee "$file_list" > /dev/null || true
+        xargs -0 sudo /bin/chmod -h -a "$SANDVAULT_DIR_RIGHTS" < "$file_list" 2>/dev/null || true
+        xargs -0 sudo /bin/chmod -h -a "$SANDVAULT_FILE_RIGHTS" < "$file_list" 2>/dev/null || true
+        xargs -0 sudo /bin/chmod -h \
+            -a "group:$SANDVAULT_GROUP allow read,write,append,delete,delete_child,readattr,writeattr,readextattr,writeextattr,readsecurity,writesecurity,chown,search,list,file_inherit,directory_inherit" \
+            < "$file_list" 2>/dev/null || true
+        rm -f "$file_list"
     fi
 }
 


### PR DESCRIPTION
The single ACL applied search/list permissions to both directories and
files, causing files to inherit an unintended execute bit. Now applies
directory-specific ACL (with search/list) and file-specific ACL
(without search/list) separately. ACL removal handles both old and
new formats for backward compatibility.
