### PR TITLE
sv: translate quoted ~ in INITIAL_DIR to sandvault user's HOME

### DIFF
--- a/sv
+++ b/sv
@@ -996,6 +996,21 @@ if [[ "$FIX_PERMISSIONS" == "true" && "$COMMAND" != "build" ]]; then
     abort "--fix-permissions can only be used standalone or with build"
 fi
 
+# Translate tilde in INITIAL_DIR to the sandvault user's HOME so that
+# `sv shell "~/foo" --` lands in /Users/$SANDVAULT_USER/foo instead of
+# silently falling back to $SHARED_WORKSPACE. Quoted "~" survives host
+# shell expansion; unquoted ~ is expanded by the host shell to the host
+# user's HOME before sv sees it and is left unchanged.
+# Compare against literal "~"; SC2088 warns about quoted tildes not expanding,
+# but here we are intentionally matching the literal character that survived
+# the host shell because the user quoted the CLI argument.
+# shellcheck disable=SC2088
+if [[ "$INITIAL_DIR" == "~" ]]; then
+    INITIAL_DIR="/Users/$SANDVAULT_USER"
+elif [[ "${INITIAL_DIR:0:2}" == "~/" ]]; then
+    INITIAL_DIR="/Users/$SANDVAULT_USER/${INITIAL_DIR:2}"
+fi
+
 # Resolve symlinks to get the real path
 INITIAL_DIR="$(cd "${INITIAL_DIR:-"${PWD}"}" 2>/dev/null && pwd -P || echo "$INITIAL_DIR")"
 readonly INITIAL_DIR


### PR DESCRIPTION
## Problem

`sv shell "~/foo" --` (and `sv codex/claude/gemini "~/foo" --`) lands in
`$SHARED_WORKSPACE` instead of `~/foo`. Same for `sv shell "~"`.

Quoted `~` reaches `sv` as a literal (bash skips tilde expansion in
quotes). The sandbox `[[ -r "$INITIAL_DIR" ]]` check in
`guest/home/.zprofile` doesn't expand it either. Silent fallback.

## Fix

Translate `~`/`~/...` to `/Users/$SANDVAULT_USER[/...]` before the cd
at `sv:1000`. Unquoted `~/foo` is already expanded by the host shell
before `sv` sees it; left as-is.

## Test

- `shellcheck sv` clean
- `sv shell "~" -- pwd` → `/Users/sandvault-$USER`
- `sv shell "~/repositories" -- pwd` → `/Users/sandvault-$USER/repositories`
- `sv shell "/private/tmp" -- pwd` → `/private/tmp` (no regression)
- `sv shell -- pwd` from host work dir → host PWD (no regression)
- `sv shell "~/repositories/foo" -- claude -p ...` lands agent in sandbox repo

## Open question

This PR only fixes the `~` case. Other unreadable PATHs still fall
back to `$SHARED_WORKSPACE` silently — `sv shell "/typo" --` ends up
in `$SHARED_WORKSPACE`, no message.
