### PR TITLE
Release v1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable user-facing changes to SandVault are documented in this file.
 
+## [1.17.0] - 2026-05-04
+
+### Added
+- Export agentsview from sandbox sessions using `sv-agentsview-setup` script.
+
+### Changed
+- Consolidate sandvault-managed paths under `_sandvault/`.
+
+### Fixed
+- File ACLs avoid creating files with the `execute` ACL.
+
+### Thanks to 2 contributors!
+
+- [@jesserobbins](https://github.com/jesserobbins) — thanks @jesserobbins!
+- [@webcoyote](https://github.com/webcoyote)
+
 ## [1.16.0] - 2026-05-01
 
 ### Fixed

--- a/sv
+++ b/sv
@@ -120,7 +120,7 @@ fi
 ###############################################################################
 # Resources
 ###############################################################################
-readonly VERSION="1.16.0"
+readonly VERSION="1.17.0"
 
 # Re-entrancy detection: if SV_SESSION_ID is already set, we're already in sandvault.
 NESTED=false


### PR DESCRIPTION
## [1.17.0] - 2026-05-04

### Added
- Export agentsview from sandbox sessions, with a standalone `sv-agentsview-setup` command for configuration.

### Changed
- Consolidate sandvault-managed paths under `_sandvault/`.
- Configure once on first use; remove the configure session-guard.
- Preserve user-customized agent directory arrays in agentsview-config instead of overriding them.
- Downgrade tolerated agentsview symlink skips from error to warning.

### Fixed
- File ACLs are now set correctly.
- agentsview-config diff no-op output no longer breaks idempotence checks.

### Thanks to 2 contributors!

- [@jesserobbins](https://github.com/jesserobbins)
- [@webcoyote](https://github.com/webcoyote)