### PR TITLE
Release v1.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable user-facing changes to SandVault are documented in this file.
 
+## [1.18.0] - 2026-05-04
+
+### Fixed
+- Fix Homebrew path resolution when sandvault is installed under `libexec` instead of `Cellar`
+
+### Thanks to 1 contributor!
+
+- [@webcoyote](https://github.com/webcoyote)
+
 ## [1.17.0] - 2026-05-04
 
 ### Added

--- a/sv
+++ b/sv
@@ -120,7 +120,7 @@ fi
 ###############################################################################
 # Resources
 ###############################################################################
-readonly VERSION="1.17.0"
+readonly VERSION="1.18.0"
 
 # Re-entrancy detection: if SV_SESSION_ID is already set, we're already in sandvault.
 NESTED=false

--- a/sv
+++ b/sv
@@ -13,10 +13,10 @@ while [[ -L "$SOURCE" ]]; do
 done
 WORKSPACE="$(cd -P "$(dirname "$SOURCE")" && pwd -P)"
 
-# If running from a Homebrew Cellar (e.g. /opt/homebrew/Cellar/sandvault/1.2.3),
+# If running from a Homebrew Cellar (e.g. /opt/homebrew/Cellar/sandvault/1.2.3/libexec),
 # use the stable opt/ symlink instead so generated scripts don't break on upgrade.
-if [[ "$WORKSPACE" =~ ^(.*)/homebrew/Cellar/([^/]+)/[^/]+$ ]]; then
-    WORKSPACE="${BASH_REMATCH[1]}/homebrew/opt/${BASH_REMATCH[2]}"
+if [[ "$WORKSPACE" =~ ^(.*)/homebrew/Cellar/([^/]+)/[^/]+(/.+)?$ ]]; then
+    WORKSPACE="${BASH_REMATCH[1]}/homebrew/opt/${BASH_REMATCH[2]}${BASH_REMATCH[3]}"
 fi
 readonly WORKSPACE
 

--- a/sv-agentsview-setup
+++ b/sv-agentsview-setup
@@ -22,10 +22,10 @@ while [[ -L "$SOURCE" ]]; do
 done
 WORKSPACE="$(cd -P "$(dirname "$SOURCE")" && pwd -P)"
 
-# If running from a Homebrew Cellar (e.g. /opt/homebrew/Cellar/sandvault/1.2.3),
+# If running from a Homebrew Cellar (e.g. /opt/homebrew/Cellar/sandvault/1.2.3/libexec),
 # use the stable opt/ symlink instead so generated scripts don't break on upgrade.
-if [[ "$WORKSPACE" =~ ^(.*)/homebrew/Cellar/([^/]+)/[^/]+$ ]]; then
-    WORKSPACE="${BASH_REMATCH[1]}/homebrew/opt/${BASH_REMATCH[2]}"
+if [[ "$WORKSPACE" =~ ^(.*)/homebrew/Cellar/([^/]+)/[^/]+(/.+)?$ ]]; then
+    WORKSPACE="${BASH_REMATCH[1]}/homebrew/opt/${BASH_REMATCH[2]}${BASH_REMATCH[3]}"
 fi
 readonly WORKSPACE
 

--- a/sv-clone
+++ b/sv-clone
@@ -31,10 +31,10 @@ while [[ -L "$SOURCE" ]]; do
 done
 WORKSPACE="$(cd -P "$(dirname "$SOURCE")" && pwd -P)"
 
-# If running from a Homebrew Cellar (e.g. /opt/homebrew/Cellar/sandvault/1.2.3),
+# If running from a Homebrew Cellar (e.g. /opt/homebrew/Cellar/sandvault/1.2.3/libexec),
 # use the stable opt/ symlink instead so generated scripts don't break on upgrade.
-if [[ "$WORKSPACE" =~ ^(.*)/homebrew/Cellar/([^/]+)/[^/]+$ ]]; then
-    WORKSPACE="${BASH_REMATCH[1]}/homebrew/opt/${BASH_REMATCH[2]}"
+if [[ "$WORKSPACE" =~ ^(.*)/homebrew/Cellar/([^/]+)/[^/]+(/.+)?$ ]]; then
+    WORKSPACE="${BASH_REMATCH[1]}/homebrew/opt/${BASH_REMATCH[2]}${BASH_REMATCH[3]}"
 fi
 readonly WORKSPACE
 


### PR DESCRIPTION
## [1.18.0] - 2026-05-04

### Fixed
- Fix Homebrew path resolution when sandvault is installed under `libexec` instead of `Cellar`

### Thanks to 1 contributor!

- [@webcoyote](https://github.com/webcoyote)