### PR TITLE
Release v1.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable user-facing changes to SandVault are documented in this file.
 
+## [1.19.0] - 2026-05-09
+
+### Added
+
+- Support for the lightpanda browser ([#161](https://github.com/webcoyote/sandvault/pull/161))
+
+### Fixed
+
+- Translate quoted `~` in `INITIAL_DIR` to the sandvault user's `HOME` ([#159](https://github.com/webcoyote/sandvault/pull/159)) — thanks @vre!
+
+### Thanks to 2 contributors!
+
+- [@vre](https://github.com/vre)
+- [@webcoyote](https://github.com/webcoyote)
+
 ## [1.18.0] - 2026-05-04
 
 ### Fixed

--- a/sv
+++ b/sv
@@ -120,7 +120,7 @@ fi
 ###############################################################################
 # Resources
 ###############################################################################
-readonly VERSION="1.18.0"
+readonly VERSION="1.19.0"
 
 # Re-entrancy detection: if SV_SESSION_ID is already set, we're already in sandvault.
 NESTED=false


### PR DESCRIPTION
## [1.19.0] - 2026-05-09

### Added

- Support for the lightpanda browser ([#161](https://github.com/webcoyote/sandvault/pull/161))

### Fixed

- Translate quoted `~` in `INITIAL_DIR` to the sandvault user's `HOME` ([#159](https://github.com/webcoyote/sandvault/pull/159)) — thanks @vre!

### Thanks to 2 contributors!

- [@vre](https://github.com/vre)
- [@webcoyote](https://github.com/webcoyote)