### PR TITLE
Preserve unicode agent args

### DIFF
--- a/guest/home/.zshrc
+++ b/guest/home/.zshrc
@@ -6,6 +6,6 @@ fi
 # Run specified application
 if [[ "${COMMAND:-}" != "" ]]; then
     # Split COMMAND_ARGS on spaces while respecting quotes using zsh's (z) flag
-    args=("${(z)COMMAND_ARGS}")
+    args=("${(@Q)${(z)COMMAND_ARGS}}")
     exec "$COMMAND" "${args[@]}"
 fi

--- a/scripts/tests
+++ b/scripts/tests
@@ -818,6 +818,60 @@ run_tests() {
     queue_test test_stdin_piping
 
     ###############################################################################
+    # Agent Args Tests
+    ###############################################################################
+
+    test_codex_unicode_args() {
+        local stub_dir="$SHARED_WORKSPACE/user/.local/bin"
+        local stub_codex_link="$stub_dir/codex"
+        local stub_codex_target
+        local backup_codex="$RESULTS_DIR/codex-$TEST_ID.backup"
+        local restore_codex=false
+        local output
+        local prompt="Reply with exactly 🍺 and no quotation marks."
+        local status
+
+        mkdir -p "$stub_dir"
+        if [[ -e "$stub_codex_link" || -L "$stub_codex_link" ]]; then
+            mv "$stub_codex_link" "$backup_codex"
+            restore_codex=true
+        fi
+        stub_codex_target=$(mktemp "$stub_dir/codex-test-stub.XXXXXX")
+        cat > "$stub_codex_target" <<'CODEX_TEST_STUB'
+#!/bin/bash
+set -Eeuo pipefail
+printf 'codex-test-stub-argc:%s\n' "$#"
+for arg in "$@"; do
+    printf 'codex-test-stub-arg:<%s>\n' "$arg"
+done
+CODEX_TEST_STUB
+        chmod +x "$stub_codex_target"
+        ln -s "$(basename "$stub_codex_target")" "$stub_codex_link"
+
+        set +e
+        output=$(/usr/bin/script -q /dev/null "${SV_CMD[@]}" --no-build codex -- "🍺" "$prompt" 2>&1)
+        status=$?
+        set -e
+
+        rm -f "$stub_codex_link" "$stub_codex_target"
+        if [[ "$restore_codex" == "true" ]]; then
+            mv "$backup_codex" "$stub_codex_link"
+            sv_cmd s -- /bin/cp -p "$stub_codex_link" "$SANDVAULT_HOME/.local/bin/codex" &>/dev/null || true
+        else
+            sv_cmd s -- /bin/rm -f "$SANDVAULT_HOME/.local/bin/codex" &>/dev/null || true
+        fi
+
+        if [[ "$status" -eq 0 && "$output" == *"codex-test-stub-arg:<🍺>"* && "$output" == *"codex-test-stub-arg:<$prompt>"* ]]; then
+            pass "sv codex -- preserves unicode args"
+        else
+            fail "sv codex -- preserves unicode args" "codex-test-stub-arg:<🍺> and codex-test-stub-arg:<$prompt>" "$status | $output"
+        fi
+    }
+    wait_for_all_running_tests
+    queue_test test_codex_unicode_args
+    wait_for_all_running_tests
+
+    ###############################################################################
     # Agentsview Export Tests
     ###############################################################################
 

--- a/sv
+++ b/sv
@@ -32,6 +32,10 @@ source "$WORKSPACE/helpers/sv-logging.sh"
 # EOF
 heredoc(){ IFS=$'\n' read -r -d '' "${1}" || true; }
 
+quote_zsh_args() {
+    /bin/zsh -fc 'for arg; do printf "%s " "${(q)arg}"; done' -- "$@"
+}
+
 git_config_set_if_changed() {
     local file="$1"
     local key="$2"
@@ -389,7 +393,12 @@ install_deps () {
         # Native install is handled inside the sandbox by guest/home/bin/* scripts;
         # ensure node is available for npm-based tools (codex, gemini).
         case "${COMMAND:-}" in
-            codex|gemini)
+            codex)
+                if [[ ! -x "$SHARED_WORKSPACE/user/.local/bin/codex" && ! -x "$SHARED_WORKSPACE/user/bin/codex" ]]; then
+                    ensure_brew_tool "node" "node"
+                fi
+                ;;
+            gemini)
                 ensure_brew_tool "node" "node"
                 ;;
             *)
@@ -403,7 +412,9 @@ install_deps () {
                 ensure_brew_tool "claude-code" "claude"
                 ;;
             codex)
-                ensure_brew_tool "codex" "codex"
+                if [[ ! -x "$SHARED_WORKSPACE/user/.local/bin/codex" && ! -x "$SHARED_WORKSPACE/user/bin/codex" ]]; then
+                    ensure_brew_tool "codex" "codex"
+                fi
                 ;;
             opencode)
                 ensure_brew_tool "anomalyco/tap/opencode" "opencode"
@@ -1827,10 +1838,11 @@ fi
 ZSH_COMMAND="$ZSH_COMMAND source ~/.zshenv; source ~/.zprofile; source ~/.zshrc"
 
 # Prepare command args as a single string
+COMMAND_ENV="$COMMAND"
 COMMAND_ARGS_STR=""
 SHELL_COMMAND_MODE=false
 if [[ ${#COMMAND_ARGS[@]} -gt 0 ]]; then
-    printf -v COMMAND_ARGS_STR '%q ' "${COMMAND_ARGS[@]}"
+    COMMAND_ARGS_STR="$(quote_zsh_args "${COMMAND_ARGS[@]}")"
 
     # When the user requests running shell (instead of an AI agent) then convert
     # COMMAND_ARGS to a command that will be run by the shell.
@@ -1843,8 +1855,13 @@ if [[ ${#COMMAND_ARGS[@]} -gt 0 ]]; then
         SHELL_COMMAND_MODE=true
     fi
 fi
+if [[ "$COMMAND" != "" ]]; then
+    ZSH_COMMAND="$ZSH_COMMAND; exec $(quote_zsh_args "$COMMAND" "${COMMAND_ARGS[@]}")"
+    COMMAND_ENV=""
+    COMMAND_ARGS_STR=""
+fi
 
-# When COMMAND is set, .zshrc will exec it — no need to append anything.
+# When COMMAND is set, it was already appended above.
 # When running a shell command (sv shell -- echo foo), it was already appended above.
 # For interactive shells (sv shell with no args), drop into a real interactive zsh
 # only when stdin is a TTY. When stdin is piped (e.g. `echo cmd | sv s`), exec a
@@ -1953,7 +1970,7 @@ if [[ "$MODE" == "ssh" ]]; then
             "USER=$SANDVAULT_USER" \
             "SHELL=/bin/zsh" \
             "TERM=${TERM:-}" \
-            "COMMAND=$COMMAND" \
+            "COMMAND=$COMMAND_ENV" \
             "COMMAND_ARGS=$COMMAND_ARGS_STR" \
             "INITIAL_DIR=$INITIAL_DIR" \
             "SHARED_WORKSPACE=$SHARED_WORKSPACE" \
@@ -1998,7 +2015,7 @@ else
             "USER=$SANDVAULT_USER" \
             "SHELL=/bin/zsh" \
             "TERM=${TERM:-}" \
-            "COMMAND=$COMMAND" \
+            "COMMAND=$COMMAND_ENV" \
             "COMMAND_ARGS=$COMMAND_ARGS_STR" \
             "INITIAL_DIR=$INITIAL_DIR" \
             "SHARED_WORKSPACE=$SHARED_WORKSPACE" \


### PR DESCRIPTION
- Avoid Bash `%q` because it can emit byte escapes that `sandbox-exec` rejects as invalid UTF-8.
- Execute agent commands from the generated zsh launch command so stale copied `.zshrc` command handling cannot leak shell quoting into args.
- Cover `codex` forwarding with unicode and spaced prompt arguments.

This is useful in Homebrew because our bug reports regularly include `🍺` in the output.