### PR TITLE
fix(native-install): use $HOME/.local npm prefix to avoid $HOME/node_modules

### DIFF
--- a/guest/home/bin/codex
+++ b/guest/home/bin/codex
@@ -7,7 +7,11 @@ source "$(dirname "${BASH_SOURCE[0]}")/sv-tool-prompts.sh"
 
 unset CODEX
 if [[ "${SV_NATIVE_INSTALL:-}" == "true" ]]; then
-    NPM_PREFIX="${HOME}/node_modules"
+    # Install under ~/.local (NOT a dir named "node_modules" at $HOME): a
+    # "node_modules" at $HOME trips Bun's ancestor-walk heuristic and disables
+    # Bun auto-install for the whole $HOME subtree (webcoyote/sandvault#169).
+    # ~/.local/bin is already on PATH via .zprofile, matching the other wrappers.
+    NPM_PREFIX="${HOME}/.local"
     NPM_BIN="$NPM_PREFIX/bin"
     if [[ ! -x "$NPM_BIN/codex" ]]; then
         echo >&2 "Installing Codex natively with npm..."

--- a/guest/home/bin/gemini
+++ b/guest/home/bin/gemini
@@ -7,7 +7,11 @@ source "$(dirname "${BASH_SOURCE[0]}")/sv-tool-prompts.sh"
 
 unset GEMINI
 if [[ "${SV_NATIVE_INSTALL:-}" == "true" ]]; then
-    NPM_PREFIX="${HOME}/node_modules"
+    # Install under ~/.local (NOT a dir named "node_modules" at $HOME): a
+    # "node_modules" at $HOME trips Bun's ancestor-walk heuristic and disables
+    # Bun auto-install for the whole $HOME subtree (webcoyote/sandvault#169).
+    # ~/.local/bin is already on PATH via .zprofile, matching the other wrappers.
+    NPM_PREFIX="${HOME}/.local"
     NPM_BIN="$NPM_PREFIX/bin"
     if [[ ! -x "$NPM_BIN/gemini" ]]; then
         echo >&2 "Installing Gemini CLI natively with npm..."

--- a/sv
+++ b/sv
@@ -329,7 +329,7 @@ ensure_brew_tool() {
     if command -v "$cli_name" &>/dev/null; then
         return 0
     fi
-    warn "Homebrew installed $tool, but no '$cli_name' CLI was found in PATH. Will use \$HOME/node_modules/bin/$cli_name if present."
+    warn "Homebrew installed $tool, but no '$cli_name' CLI was found in PATH. Will use \$HOME/.local/bin/$cli_name if present."
     return 0
 }
 


### PR DESCRIPTION
# fix(native-install): avoid `$HOME/node_modules` npm prefix that disables Bun auto-install

Closes #169.

## Problem

The native-install branch of the `codex` and `gemini` wrappers installs with
`npm install --prefix "$HOME/node_modules" -g <pkg>`. Using `$HOME/node_modules`
as the prefix plants a directory **literally named `node_modules` at `$HOME`**.

Bun resolves modules by walking up the directory tree for the nearest ancestor
`node_modules` and treats it as a package boundary. Finding one at `$HOME`
**disables Bun's auto-install for the entire `$HOME` subtree** — so any tool run
under the user's home that relies on Bun fetching imports on first use breaks
with `Cannot find package '<x>'`. The failure is non-obvious: it only appears
once `SV_NATIVE_INSTALL` has run, and looks like a per-project dependency
problem rather than an environment-wide one. The directory is also self-healing
— the wrapper recreates it on the next run — so deleting it isn't a durable
workaround.

## Fix

Switch the npm prefix to `$HOME/.local`:

```diff
-    NPM_PREFIX="${HOME}/node_modules"
+    NPM_PREFIX="${HOME}/.local"
```

`npm install --prefix "$HOME/.local" -g <pkg>` puts the launcher in
`~/.local/bin` and the package tree in `~/.local/lib/node_modules` — functionally
identical, but **no `node_modules` directory at `$HOME`**, so Bun's heuristic is
unaffected.

`~/.local` is also the convention this repo already uses:

- `guest/home/bin/claude` and `guest/home/bin/opencode` install into
  `$HOME/.local/bin`.
- `guest/home/.zprofile` puts `$HOME/.local/bin` first on `PATH` (it was never
  adding `$HOME/node_modules/bin`).

So `codex`/`gemini` now align with the other wrappers, and the user-facing fallback
hint in `sv` (`ensure_brew_tool`) is updated to name the correct, on-`PATH`
location.

## Changes

- `guest/home/bin/codex` — prefix → `$HOME/.local` (+ comment explaining the Bun footgun)
- `guest/home/bin/gemini` — same
- `sv` — `ensure_brew_tool` warn message now points at `$HOME/.local/bin/<cli>`

## Applying to an existing install requires a rebuild

Updating the wrapper files alone does **not** fix an already-provisioned sandbox.
The sandbox home is populated by a cached sudoers build-home script
(`/var/sandvault/buildhome-<user>`) whose rsync **source path is baked in when the
script is generated**, and that script is only regenerated on `--rebuild` (or when
the sandbox profile is missing). So after upgrading, existing users must run a
rebuild for the new wrappers to land in `~/bin`:

```sh
sv --rebuild -N codex      # (and -N gemini) — regenerates the build-home script
```

New installs pick up the fix directly. (Verified: without `--rebuild`, a launch
re-runs the cached script and redeploys the old wrapper; with `--rebuild`, `~/bin/codex`
updates and codex installs into `~/.local`.)

## Migration for existing users — OPEN QUESTION (no safe automated answer yet)

The prefix change is safe for **new** installs. Existing native-install users
already have a populated `~/node_modules` on disk, and it keeps tripping Bun's
ancestor walk until removed. This is exactly the "make sure this doesn't break
existing users" concern raised on the issue — and we do **not** yet have a safe
*automated* migration. The hard part is doing it in code without breaking anyone:

- A blind `rm -rf ~/node_modules` in code is dangerous — sandvault can't reliably
  distinguish its own old npm-prefix directory from a `~/node_modules` a user
  created for some other reason. Deleting the wrong one is data loss.
- The wrappers run on every invocation — the wrong place for a one-time
  destructive migration.
- An `sv` run-once migration marker is the least-bad code option, but it still
  has to answer "is this directory safe to delete?", which is the unsolved part.

**Interim (manual, user-owned):** after upgrading, the user clears it once
themselves — `rm -rf ~/node_modules` — keeping the destructive decision with the
person who owns the data.

Flagging the automated migration as **unresolved**. Options to discuss: a guarded
run-once cleanup (only if the dir looks like sandvault's old prefix), a
warning-only detector that tells the user to clean up, or leaving it as
documented manual cleanup. Happy to follow your preference here.

## Testing

- `shellcheck guest/home/bin/codex guest/home/bin/gemini sv` — clean.
- Isolated verification with a fake `$HOME` and a stubbed `npm` (no real global
  install): the install branch passes `--prefix $HOME/.local -g <correct-pkg>`,
  the resolved launcher is `$HOME/.local/bin/<tool>`, the argv contains zero
  `node_modules` paths, and no `$HOME/node_modules` reference remains in any
  changed file.

## Note on possible follow-up (not in this PR)

The `codex` and `gemini` native-install blocks are now identical copy-paste. A
small shared helper (parameterized by tool + package) would prevent them from
drifting — happy to do that separately if you'd like.
