### PR TITLE
Release v1.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable user-facing changes to SandVault are documented in this file.
 
+## [1.21.0] - 2026-06-10
+
+### Changed
+
+- `sv-clone` now uses a read-only token instead of a read-write token, reducing the blast radius of a rogue agent. ([#170](https://github.com/webcoyote/sandvault/pull/170)) — thanks @MikeMcQuaid!
+
+### Thanks to 1 contributor!
+
+- [@MikeMcQuaid](https://github.com/MikeMcQuaid)
+
 ## [1.20.0] - 2026-05-11
 
 ### Changed

--- a/sv
+++ b/sv
@@ -124,7 +124,7 @@ fi
 ###############################################################################
 # Resources
 ###############################################################################
-readonly VERSION="1.20.0"
+readonly VERSION="1.21.0"
 
 # Re-entrancy detection: if SV_SESSION_ID is already set, we're already in sandvault.
 NESTED=false


### PR DESCRIPTION
## [1.21.0] - 2026-06-10

### Changed

- `sv-clone` now uses a read-only token instead of a read-write token, reducing the blast radius of rogue agents. ([#170](https://github.com/webcoyote/sandvault/pull/170)) — thanks @MikeMcQuaid!

### Thanks to 1 contributor!

- [@MikeMcQuaid](https://github.com/MikeMcQuaid)