### PR TITLE
Trust shared Sandvault repos

### DIFF
--- a/scripts/tests
+++ b/scripts/tests
@@ -20,6 +20,7 @@ fi
 HOST_HOME="$(dscl . -read "/Users/$HOST_USER" NFSHomeDirectory | cut -d' ' -f2)"
 SANDVAULT_USER="sandvault-$HOST_USER"
 SANDVAULT_HOME="/Users/$SANDVAULT_USER"
+SHARED_WORKSPACE="/Users/Shared/sv-$HOST_USER"
 
 [[ "${VERBOSE:-0}" =~ ^[0-9]+$ ]] && VERBOSE="${VERBOSE:-0}" || VERBOSE=1
 
@@ -496,6 +497,21 @@ run_tests() {
 
     queue_test assert_sandbox_path_order "\$USER/bin precedes /opt/homebrew/bin" "$SANDVAULT_HOME/bin" "/opt/homebrew/bin"
 
+    test_git_trusts_shared_workspace_from_env() {
+        local output
+        local status
+        set +e
+        output=$(sv_cmd s -- sh -c 'GIT_CONFIG_GLOBAL=/dev/null git config --get-all safe.directory' 2>&1)
+        status=$?
+        set -e
+        if [[ "$status" -eq 0 ]] && printf '%s\n' "$output" | grep -Fx "$SHARED_WORKSPACE/*" &>/dev/null; then
+            pass "git trusts shared workspace from session env"
+        else
+            fail "git trusts shared workspace from session env" "$SHARED_WORKSPACE/*" "$status | $output"
+        fi
+    }
+    queue_test test_git_trusts_shared_workspace_from_env
+
     ###############################################################################
     # Sandbox Escape Tests: Host User Files
     ###############################################################################
@@ -539,7 +555,6 @@ run_tests() {
     ###############################################################################
 
     # Should be able to access shared workspace
-    SHARED_WORKSPACE="/Users/Shared/sv-$HOST_USER"
     queue_test assert_sandbox_pipe_contains "can access shared workspace" "ls $SHARED_WORKSPACE" "SANDVAULT-README"
     queue_test assert_sandbox_exit_code "sv s -- touch SANDVAULT-README.md" 0 touch -c "$SHARED_WORKSPACE/SANDVAULT-README.md"
 
@@ -637,7 +652,7 @@ run_tests() {
         local expected_upstream
 
         src_repository="$(git -C "$SCRIPT_DIR/.." rev-parse --show-toplevel 2>/dev/null || true)"
-        if [[ -z "$src_repository" || ! -d "$src_repository/.git" ]]; then
+        if [[ -z "$src_repository" ]] || ! git -C "$src_repository" rev-parse --git-dir &>/dev/null; then
             fail "sv-clone clones local repository" "current repository available" "$src_repository"
             return
         fi

--- a/sv
+++ b/sv
@@ -1647,14 +1647,16 @@ elif [[ "$REBUILD" == "true" ]]; then
 
     mkdir -p "$SV_PRIVATE_DIR/setup"
 
-    # .gitconfig: seed if missing, preserving user overrides
+    # .gitconfig: seed identity if missing, preserving user overrides
     cat > "$SV_PRIVATE_DIR/setup/gitconfig" << SETUP_EOF
 #!/bin/bash
 set -Eeuo pipefail
 if [[ ! -f "\$HOME/.gitconfig" ]]; then
     git config -f "\$HOME/.gitconfig" user.name "$GIT_USER_NAME"
     git config -f "\$HOME/.gitconfig" user.email "$GIT_USER_EMAIL"
-    git config -f "\$HOME/.gitconfig" safe.directory "$SHARED_WORKSPACE/*"
+fi
+if ! git config -f "\$HOME/.gitconfig" --get-all safe.directory 2>/dev/null | /usr/bin/grep -Fx "$SHARED_WORKSPACE/*" &>/dev/null; then
+    git config -f "\$HOME/.gitconfig" --add safe.directory "$SHARED_WORKSPACE/*"
 fi
 SETUP_EOF
     chmod +x "$SV_PRIVATE_DIR/setup/gitconfig"
@@ -1885,6 +1887,13 @@ fi
 # is how nested `sv --browser` / `sv --ios` invocations inherit
 # SV_BROWSER_ENDPOINT / SV_IOS_SIMULATOR_ENDPOINT from the parent session.
 EXTRA_ENV=()
+EXTRA_ENV+=("GIT_CONFIG_COUNT=1")
+EXTRA_ENV+=("GIT_CONFIG_KEY_0=safe.directory")
+if [[ "$MODE" == "ssh" ]]; then
+    EXTRA_ENV+=("GIT_CONFIG_VALUE_0=$SHARED_WORKSPACE/\\*")
+else
+    EXTRA_ENV+=("GIT_CONFIG_VALUE_0=$SHARED_WORKSPACE/*")
+fi
 if [[ "$NATIVE_INSTALL" == "true" ]]; then
     EXTRA_ENV+=("SV_NATIVE_INSTALL=true")
 fi


### PR DESCRIPTION
- Keep Git usable in shared-workspace worktrees owned by the host user
- Apply the trust per session so existing sandbox homes work immediately
- Avoid assuming `.git` is a directory when testing local clones