### PR TITLE
Add pi as a first-class agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SandVault (`sv`) manages a limited user account to sandbox shell commands and AI
 </br>
 </br>
 
-- **AI ready** - Includes Claude Code, OpenAI Codex, OpenCode, Google Gemini
+- **AI ready** - Includes Claude Code, OpenAI Codex, OpenCode, Google Gemini, pi
 - **Web and iOS automation** - sandbox access to Chrome / Lightpanda and iOS Simulator
 - **Fast context switching** - No VM overhead; instant user switching
 - **Passwordless** - switch accounts without a prompt (after setup)
@@ -90,6 +90,10 @@ Install via git:
 # shortcut: sv g
   sv gemini
 
+# Run pi in the sandbox
+# shortcut: sv p
+  sv pi
+
 # Run command shell in the sandbox
 # shortcut: sv s
   sv shell
@@ -165,6 +169,7 @@ By default, SandVault installs AI tools via Homebrew on the host side. With `--n
 - **Codex** — installed via `npm install -g @openai/codex`
 - **OpenCode** — installed via `curl -fsSL https://opencode.ai/install | bash`
 - **Gemini** — installed via `npm install -g @google/gemini-cli`
+- **pi** — installed via `npm install -g @earendil-works/pi-coding-agent`
 
 Tools are installed on first run and reused on subsequent runs.
 
@@ -177,6 +182,7 @@ sv -N claude
 sv -N codex
 sv -N opencode
 sv -N gemini
+sv -N pi
 ```
 
 To make native install the default, set `SANDVAULT_ARGS`:
@@ -240,7 +246,7 @@ Explicit command-line arguments are appended after `SANDVAULT_ARGS`, so they are
 
 ## `agentsview` Integration
 
-[`agentsview`](https://github.com/badlogic/agentsview) is a dashboard that aggregates session history, search, and cost tracking across AI coding agents (Claude Code, Codex, OpenCode, Gemini). If you have agentsview installed on the host, `sv-agentsview-setup` mirrors sandbox session data so it appears alongside your host-side sessions.
+[`agentsview`](https://github.com/badlogic/agentsview) is a dashboard that aggregates session history, search, and cost tracking across AI coding agents (Claude Code, Codex, OpenCode, Gemini, pi). If you have agentsview installed on the host, `sv-agentsview-setup` mirrors sandbox session data so it appears alongside your host-side sessions.
 
 ```bash
 # Detect agentsview, prompt to opt in, and configure
@@ -507,6 +513,7 @@ After exploring Docker containers, Podman, sandbox-exec, and virtualization, I n
 - Runs OpenAI Codex with `--dangerously-bypass-approvals-and-sandbox`
 - Runs OpenCode with `OPENCODE_PERMISSION='{"*":"allow"}'`
 - Runs Google Gemini with `--yolo`
+- Runs pi with `--approve` to trust project-local files (pi needs no permission bypass)
 - Automates Chrome for web testing (via Chrome DevTools Protocol)
 - Automated iOS Simulator for app testing (via `xcrun simctl`, and `iosef`)
 - Maintains a clean separation between trusted and untrusted code

--- a/guest/home/bin/pi
+++ b/guest/home/bin/pi
@@ -1,0 +1,70 @@
+#!/bin/bash
+set -Eeuo pipefail
+trap 'echo >&2 "${BASH_SOURCE[0]}: line $LINENO: $BASH_COMMAND: exitcode $?"' ERR
+
+# shellcheck source=sv-tool-prompts.sh
+source "$(dirname "${BASH_SOURCE[0]}")/sv-tool-prompts.sh"
+
+unset PI
+if [[ "${SV_NATIVE_INSTALL:-}" == "true" ]]; then
+    # Install under ~/.local (NOT a dir named "node_modules" at $HOME): a
+    # "node_modules" at $HOME trips Bun's ancestor-walk heuristic and disables
+    # Bun auto-install for the whole $HOME subtree (webcoyote/sandvault#169).
+    # ~/.local/bin is already on PATH via .zprofile, matching the other wrappers.
+    NPM_PREFIX="${HOME}/.local"
+    NPM_BIN="$NPM_PREFIX/bin"
+    if [[ ! -x "$NPM_BIN/pi" ]]; then
+        echo >&2 "Installing pi natively with npm..."
+        npm install --prefix "$NPM_PREFIX" -g @earendil-works/pi-coding-agent
+    fi
+    PI="$NPM_BIN/pi"
+elif command -v brew &>/dev/null ; then
+    HOMEBREW_PREFIX="${HOMEBREW_PREFIX:-"$(brew --prefix)"}"
+    if [[ -x "$HOMEBREW_PREFIX/bin/pi" ]]; then
+        # Homebrew install
+        PI="$HOMEBREW_PREFIX/bin/pi"
+    fi
+fi
+
+# Fallback: a pre-existing install at a known location. Covers a prior
+# native install at ~/.local/bin/pi and the common Bun-global install at
+# ~/.bun/bin/pi, neither of which the native-install or Homebrew paths above
+# cover. We check explicit paths rather than `command -v pi` because this
+# wrapper itself is installed at ~/bin/pi in the sandbox and $HOME/bin precedes
+# these on PATH, so a generic PATH search would resolve to this wrapper and
+# re-exec it in an infinite loop.
+if [[ -z "${PI:-}" || ! -x "$PI" ]]; then
+    if [[ -x "$HOME/.local/bin/pi" ]]; then
+        PI="$HOME/.local/bin/pi"
+    elif [[ -x "$HOME/.bun/bin/pi" ]]; then
+        PI="$HOME/.bun/bin/pi"
+    fi
+fi
+
+if [[ -z "${PI:-}" || ! -x "$PI" ]]; then
+    # Don't suggest staging under $SHARED_WORKSPACE/user/{bin,.local/bin}:
+    # .zprofile puts both ahead of $HOME/bin, so a pi there shadows this
+    # wrapper instead of being found by it, silently dropping --approve and
+    # the tool prompt. The paths below are inside the sandbox home, which is
+    # separate from your host home -- reach it with `sv shell`.
+    echo >&2 "ERROR: pi is not installed."
+    echo >&2 "       To install pi on the host, run 'brew install pi-coding-agent'."
+    echo >&2 "       To install pi in the sandbox, run 'sv -N pi'."
+    echo >&2 "       To use an install you already have, put it at ~/.local/bin/pi"
+    echo >&2 "       or ~/.bun/bin/pi in the sandbox home. Use 'sv shell' to get there."
+    exit 1
+fi
+
+TOOL_PROMPT=$(sv_tool_prompt)
+EXTRA_ARGS=()
+if [[ -n "$TOOL_PROMPT" ]]; then
+    EXTRA_ARGS+=(--append-system-prompt "$TOOL_PROMPT")
+fi
+
+# Unlike the other agents, pi needs no permission-bypass flag: it runs its
+# read/bash/edit/write tools without prompting. --approve answers a different
+# question -- pi's interactive project-trust prompt -- so project-local
+# extensions, skills, prompt templates, and themes load without stopping for
+# input. That is a real trust decision, and the sandbox is where to make it.
+echo >&2 "$USER: running pi ($PI) --approve (trusts project-local files)"
+exec "$PI" --approve ${EXTRA_ARGS[@]+"${EXTRA_ARGS[@]}"} "$@"

--- a/helpers/agentsview-config.py
+++ b/helpers/agentsview-config.py
@@ -28,6 +28,7 @@ VALID_KEYS = {
     "codex_sessions_dirs",
     "opencode_dirs",
     "gemini_dirs",
+    "pi_dirs",
 }
 
 DEFAULT_SUBPATHS = {
@@ -35,6 +36,7 @@ DEFAULT_SUBPATHS = {
     "codex_sessions_dirs": ".codex/sessions",
     "opencode_dirs": ".local/share/opencode",
     "gemini_dirs": ".gemini",
+    "pi_dirs": ".pi/agent/sessions",
 }
 
 
@@ -118,8 +120,8 @@ def run_self_test() -> None:
 
         all_agents = [(k, f"/mnt/mirror/{k}") for k in VALID_KEYS]
 
-        # Test 1: Missing config file -> creates all four keys [default, mirror]
-        name = "missing config -> all four keys"
+        # Test 1: Missing config file -> creates all keys [default, mirror]
+        name = "missing config -> all keys"
         try:
             cfg = read_config(config_path)
             updated = apply_agents(cfg, all_agents, home)
@@ -142,8 +144,8 @@ def run_self_test() -> None:
         except Exception:
             fail(name, traceback.format_exc())
 
-        # Test 2: Existing file with empty dict -> adds all four keys
-        name = "empty file -> all four keys"
+        # Test 2: Existing file with empty dict -> adds all keys
+        name = "empty file -> all keys"
         try:
             os.makedirs(config_dir, exist_ok=True)
             with open(config_path, "w") as f:

--- a/helpers/agentsview-paths.sh
+++ b/helpers/agentsview-paths.sh
@@ -7,13 +7,23 @@
 # Use bash 3.2-safe variable indirection: AGENTSVIEW_<field>_<agent>="..."
 # rather than associative arrays.
 
-AGENTSVIEW_AGENTS=(claude codex opencode gemini)
+AGENTSVIEW_AGENTS=(claude codex opencode gemini pi)
 
 # Sandbox-side path under /Users/sandvault-$USER/
 AGENTSVIEW_SUBDIR_claude=".claude/projects"
 AGENTSVIEW_SUBDIR_codex=".codex/sessions"
 AGENTSVIEW_SUBDIR_opencode=".local/share/opencode"
 AGENTSVIEW_SUBDIR_gemini=".gemini"
+AGENTSVIEW_SUBDIR_pi=".pi/agent/sessions"
+
+# Optional: a directory on the way to SUBDIR that holds credentials and must
+# not become group-readable. `mkdir -p` creates intermediates at 0755 under the
+# default umask, and an agent that would have created the directory itself with
+# tighter permissions never gets the chance -- pi's auth-storage applies 0700 at
+# mkdir time only, and never chmods a directory that already exists. Only set
+# this where the agent keeps secrets in a parent of its session directory; the
+# other agents' session dirs have no such parent, so they have no entry.
+AGENTSVIEW_PRIVATE_pi=".pi/agent"
 
 # Host-side default path under $HOME (matches agentsview's
 # parser.Registry DefaultDirs)
@@ -21,12 +31,14 @@ AGENTSVIEW_DEFAULT_claude=".claude/projects"
 AGENTSVIEW_DEFAULT_codex=".codex/sessions"
 AGENTSVIEW_DEFAULT_opencode=".local/share/opencode"
 AGENTSVIEW_DEFAULT_gemini=".gemini"
+AGENTSVIEW_DEFAULT_pi=".pi/agent/sessions"
 
 # Top-level TOML key in ~/.agentsview/config.toml
 AGENTSVIEW_TOMLKEY_claude="claude_project_dirs"
 AGENTSVIEW_TOMLKEY_codex="codex_sessions_dirs"
 AGENTSVIEW_TOMLKEY_opencode="opencode_dirs"
 AGENTSVIEW_TOMLKEY_gemini="gemini_dirs"
+AGENTSVIEW_TOMLKEY_pi="pi_dirs"
 
 # Look up a field for an agent. Usage: agentsview_field SUBDIR claude
 agentsview_field() {

--- a/scripts/tests
+++ b/scripts/tests
@@ -344,6 +344,17 @@ run_tests() {
     }
     queue_test test_help_lists_opencode
 
+    test_help_lists_pi() {
+        local output
+        output=$(sv_cmd --help 2>&1)
+        if [[ "$output" == *"p,  pi"* ]]; then
+            pass "--help lists pi"
+        else
+            fail "--help lists pi" "pi command line" "$output"
+        fi
+    }
+    queue_test test_help_lists_pi
+
     test_opencode_wrapper_uses_skip_permissions() {
         if [[ -x "$SCRIPT_DIR/../guest/home/bin/opencode" ]] \
             && grep -F -- "OPENCODE_PERMISSION" \
@@ -409,6 +420,140 @@ EOF
         fi
     }
     queue_test test_configure_tolerates_already_unlocked_keychain
+
+    # Mirror the opencode test for pi: assert the wrapper wires the
+    # project-trust flag (--approve, which skips pi's interactive trust prompt;
+    # pi needs no permission-bypass flag) and the shared tool-prompt injection
+    # (--append-system-prompt).
+    test_pi_wrapper_wires_trust_and_prompt() {
+        local wrapper="$SCRIPT_DIR/../guest/home/bin/pi"
+        if [[ ! -x "$wrapper" ]]; then
+            fail "pi wrapper wires trust and prompt" "executable wrapper" "$wrapper"
+            return
+        fi
+        # Anchor --approve to the exec line: it appears in two comments and the
+        # startup banner as well, so a whole-file grep stays green after it is
+        # deleted from the exec -- exactly the drift this guards.
+        # --append-system-prompt goes into EXTRA_ARGS rather than onto the exec
+        # line, so match it in comment-stripped code instead.
+        local code
+        code=$(grep -vE '^[[:space:]]*#' "$wrapper" | sed 's/[[:space:]]#.*$//')
+        if grep -Eq '^exec .*--approve' "$wrapper" \
+            && grep -F -- '--append-system-prompt' <<< "$code" &>/dev/null; then
+            pass "pi wrapper wires trust and prompt"
+        else
+            fail "pi wrapper wires trust and prompt" \
+                "--approve on the exec line and --append-system-prompt in code" \
+                "$wrapper"
+        fi
+    }
+    queue_test test_pi_wrapper_wires_trust_and_prompt
+
+    # Guard the dispatch mapping: a typo in (or removal of) the p|pi) case arm
+    # would pass the wrapper static tests but break 'sv pi'. Assert sv has a
+    # p|pi) arm that sets COMMAND=pi. (A full end-to-end stub test like
+    # test_codex_unicode_args isn't safe for pi: the wrapper's Homebrew branch
+    # takes precedence over the ~/.local/bin/pi fallback, so a host with a
+    # brew pi installed would run the real binary, not the stub.)
+    test_sv_dispatches_pi() {
+        if grep -Eq '^[[:space:]]+p[|]pi\)' "$SV_BASE" \
+            && grep -A2 -E '^[[:space:]]+p[|]pi\)' "$SV_BASE" | grep -q 'COMMAND=pi'; then
+            pass "sv dispatches p|pi -> COMMAND=pi"
+        else
+            fail "sv dispatches p|pi -> COMMAND=pi" \
+                "a p|pi) case arm setting COMMAND=pi" \
+                "missing or broken dispatch arm in $SV_BASE"
+        fi
+    }
+    queue_test test_sv_dispatches_pi
+
+    # pi installs from the homebrew/core "pi-coding-agent" formula, whose name
+    # differs from its "pi" binary. ensure_brew_tool takes both, and passing
+    # only the formula name would look for a "pi-coding-agent" binary that does
+    # not exist, reinstalling on every run.
+    test_sv_installs_pi_via_brew_formula() {
+        if grep -F -- 'ensure_brew_tool "pi-coding-agent" "pi"' "$SV_BASE" &>/dev/null; then
+            pass "sv installs pi via the pi-coding-agent formula"
+        else
+            fail "sv installs pi via the pi-coding-agent formula" \
+                'ensure_brew_tool "pi-coding-agent" "pi"' \
+                "missing or broken install arm in $SV_BASE"
+        fi
+    }
+    queue_test test_sv_installs_pi_via_brew_formula
+
+    # Same error class as the formula name, on the other install path: a typo in
+    # the npm package name surfaces only at runtime under 'sv -N pi', which the
+    # suite never exercises.
+    test_pi_wrapper_native_install_package() {
+        local wrapper="$SCRIPT_DIR/../guest/home/bin/pi"
+        if grep -F -- 'npm install --prefix "$NPM_PREFIX" -g @earendil-works/pi-coding-agent' \
+            "$wrapper" &>/dev/null; then
+            pass "pi wrapper native-installs @earendil-works/pi-coding-agent"
+        else
+            fail "pi wrapper native-installs @earendil-works/pi-coding-agent" \
+                'npm install --prefix "$NPM_PREFIX" -g @earendil-works/pi-coding-agent' \
+                "$wrapper"
+        fi
+    }
+    queue_test test_pi_wrapper_native_install_package
+
+    # Guard the agentsview wiring (which the round-6 review caught drifting):
+    # pi must be in AGENTSVIEW_AGENTS with the correct session subdir and TOML
+    # key, so the generated setup-merge script and host config both pick it up.
+    test_agentsview_wires_pi() {
+        local paths="$SCRIPT_DIR/../helpers/agentsview-paths.sh"
+        if [[ ! -r "$paths" ]]; then
+            fail "agentsview wires pi" "readable agentsview-paths.sh" "$paths"
+            return
+        fi
+        # shellcheck source=/dev/null
+        source "$paths"
+        local found=false agent
+        for agent in "${AGENTSVIEW_AGENTS[@]}"; do
+            [[ "$agent" == "pi" ]] && found=true
+        done
+        local subdir tomlkey
+        subdir="$(agentsview_field SUBDIR pi)"
+        tomlkey="$(agentsview_field TOMLKEY pi)"
+        if [[ "$found" == "true" && "$subdir" == ".pi/agent/sessions" && "$tomlkey" == "pi_dirs" ]]; then
+            pass "agentsview wires pi"
+        else
+            fail "agentsview wires pi" \
+                "pi in AGENTSVIEW_AGENTS, SUBDIR=.pi/agent/sessions, TOMLKEY=pi_dirs" \
+                "found=$found subdir=$subdir tomlkey=$tomlkey"
+        fi
+    }
+    queue_test test_agentsview_wires_pi
+
+    # Regression guard: the pi wrapper must NOT resolve its own binary via a
+    # PATH search (command -v pi / type -P pi). The wrapper is installed at
+    # ~/bin/pi in the sandbox and $HOME/bin precedes ~/.bun/bin on PATH, so a
+    # PATH search resolves to the wrapper itself and re-execs in an infinite
+    # loop. It must use the explicit ~/.bun/bin/pi path instead. Comment lines
+    # are stripped so the explanatory comment (which mentions command -v pi)
+    # does not false-positive.
+    test_pi_wrapper_no_command_v_loop() {
+        local wrapper="$SCRIPT_DIR/../guest/home/bin/pi"
+        if [[ ! -x "$wrapper" ]]; then
+            fail "pi wrapper has no command -v loop" "executable wrapper" "$wrapper"
+            return
+        fi
+        local code
+        code=$(grep -vE '^[[:space:]]*#' "$wrapper" | sed 's/[[:space:]]#.*$//')
+        if echo "$code" | grep -E 'command -v pi\b|type -P pi\b|type -aP pi\b' &>/dev/null; then
+            fail "pi wrapper has no command -v loop" \
+                "no PATH-search fallback for pi" \
+                "wrapper resolves pi via command -v/type -P (would self-resolve and loop)"
+        elif ! echo "$code" | grep -F -- '"$HOME/.bun/bin/pi"' &>/dev/null; then
+            fail "pi wrapper has no command -v loop" \
+                "explicit ~/.bun/bin/pi fallback" \
+                "wrapper missing safe fallback path"
+        else
+            pass "pi wrapper has no command -v loop"
+        fi
+    }
+    queue_test test_pi_wrapper_no_command_v_loop
 
     # Unknown option
     test_unknown_option() {
@@ -497,7 +642,7 @@ EOF
         fi
         local failed=false
         local link
-        for link in claude codex opencode gemini; do
+        for link in claude codex opencode gemini pi; do
             if [[ -L "$brew_prefix/bin/$link" ]]; then
                 local link_perms
                 link_perms=$(/usr/bin/stat -f "%Lp" "$brew_prefix/bin/$link")
@@ -1357,22 +1502,35 @@ CODEX_TEST_STUB
     }
     queue_test test_agentsview_config_writer_self_test
 
-    # End-to-end: --diff against an empty file produces the expected four-key
-    # TOML, and --write produces a file that re-parses cleanly with the same
-    # tool (round-trip stability).
+    # End-to-end: --write produces a file that re-parses cleanly with the same
+    # tool (round-trip stability), and a second --diff is empty. The --agent
+    # list is built from AGENTSVIEW_AGENTS rather than hardcoded, so every
+    # agent -- present and future -- exercises the Python side. That matters
+    # because a key in VALID_KEYS but missing from DEFAULT_SUBPATHS passes
+    # validation and then raises KeyError inside default_host_path on the write
+    # path: a crash mid-`sv-agentsview-setup`, not a clean error.
     test_agentsview_config_writer_round_trip() {
-        local tmpdir cfg home output status
+        local paths="$SCRIPT_DIR/../helpers/agentsview-paths.sh"
+        if [[ ! -r "$paths" ]]; then
+            fail "agentsview config writer round-trip" "readable agentsview-paths.sh" "$paths"
+            return
+        fi
+        # shellcheck source=/dev/null
+        source "$paths"
+        local tmpdir cfg home output status agent tomlkey
         tmpdir=$(mktemp -d)
         cfg="$tmpdir/config.toml"
         home="$tmpdir/home"
         mkdir -p "$home"
+        local agent_args=()
+        for agent in "${AGENTSVIEW_AGENTS[@]}"; do
+            tomlkey="$(agentsview_field TOMLKEY "$agent")"
+            agent_args+=(--agent "$tomlkey=$tmpdir/sessions/$agent")
+        done
         set +e
         /usr/bin/python3 "$AGENTSVIEW_CONFIG_SCRIPT" \
             --config-path "$cfg" --home "$home" --write \
-            --agent claude_project_dirs="$tmpdir/sessions/claude" \
-            --agent codex_sessions_dirs="$tmpdir/sessions/codex" \
-            --agent opencode_dirs="$tmpdir/sessions/opencode" \
-            --agent gemini_dirs="$tmpdir/sessions/gemini" \
+            "${agent_args[@]}" \
             > /dev/null 2>&1
         status=$?
         set -e
@@ -1385,20 +1543,149 @@ CODEX_TEST_STUB
         set +e
         output=$(/usr/bin/python3 "$AGENTSVIEW_CONFIG_SCRIPT" \
             --config-path "$cfg" --home "$home" --diff \
-            --agent claude_project_dirs="$tmpdir/sessions/claude" \
-            --agent codex_sessions_dirs="$tmpdir/sessions/codex" \
-            --agent opencode_dirs="$tmpdir/sessions/opencode" \
-            --agent gemini_dirs="$tmpdir/sessions/gemini" 2>&1)
+            "${agent_args[@]}" 2>&1)
         status=$?
         set -e
         rm -rf "$tmpdir"
         if [[ "$status" -eq 0 && -z "$output" ]]; then
             pass "agentsview config writer round-trip is idempotent"
         else
-            fail "agentsview config writer round-trip is idempotent" "empty diff" "exit $status, output: $output"
+            fail "agentsview config writer round-trip is idempotent" \
+                "empty diff" "exit $status, output: $output"
         fi
     }
     queue_test test_agentsview_config_writer_round_trip
+
+    # The setup-merge generator interpolates SUBDIR values into a quoted list
+    # for the sandbox-side ACL loop. Two silent failure modes: a quoting break
+    # makes the generated script a syntax error, and guest/home/configure runs
+    # it under `set -Eeuo pipefail`, so sandbox startup aborts entirely; and an
+    # agent with an empty SUBDIR yields a `""` element whose loop body resolves
+    # to "$HOME/" and applies an inheriting group-read ACL to the whole sandbox
+    # home, every session. Assert the real SUBDIR values assemble into a list
+    # that parses, and that both guards against the empty case are in place.
+    test_agentsview_setup_merge_generation_is_safe() {
+        local paths="$SCRIPT_DIR/../helpers/agentsview-paths.sh"
+        local setup="$SCRIPT_DIR/../sv-agentsview-setup"
+        if [[ ! -r "$paths" || ! -r "$setup" ]]; then
+            fail "agentsview setup-merge generation is safe" "readable sources" "$paths $setup"
+            return
+        fi
+        # shellcheck source=/dev/null
+        source "$paths"
+        local agent _q _subdir subdir_list="" empty_found=false
+        for agent in "${AGENTSVIEW_AGENTS[@]}"; do
+            _subdir="$(agentsview_field SUBDIR "$agent")"
+            [[ -n "$_subdir" ]] || empty_found=true
+            printf -v _q '"%s" ' "$_subdir"
+            subdir_list+="$_q"
+        done
+        # The assembled loop must parse as bash with the real values in it.
+        local probe parses=false
+        probe=$(mktemp)
+        printf 'for subdir in %s; do :; done\n' "$subdir_list" > "$probe"
+        bash -n "$probe" 2>/dev/null && parses=true
+        rm -f "$probe"
+        # Generator aborts on an empty SUBDIR; generated script skips one.
+        local gen_guard=false run_guard=false
+        grep -F -- 'has no SUBDIR"' "$setup" &>/dev/null && gen_guard=true
+        grep -F -- '[[ -n "\$subdir" ]] || continue' "$setup" &>/dev/null && run_guard=true
+        if [[ "$empty_found" == "false" && "$parses" == "true" \
+            && "$gen_guard" == "true" && "$run_guard" == "true" ]]; then
+            pass "agentsview setup-merge generation is safe"
+        else
+            fail "agentsview setup-merge generation is safe" \
+                "no empty SUBDIR, list parses, generator aborts and generated script skips on empty" \
+                "empty=$empty_found parses=$parses gen_guard=$gen_guard run_guard=$run_guard"
+        fi
+    }
+    queue_test test_agentsview_setup_merge_generation_is_safe
+
+    # pi keeps auth.json in ~/.pi/agent, a parent of its session dir. mkdir -p
+    # would create that parent at 0755 under the default umask, and pi's
+    # auth-storage only applies 0700 at creation time -- it never chmods a
+    # directory that already exists, so sandvault pre-creating it leaves the
+    # credential directory group-listable for the life of the sandbox home. The
+    # generated script must tighten it to 0700 with a traverse-only ACE, and
+    # must do so *before* the session-dir loop, since mkdir -p on the session
+    # dir would otherwise create the parent first at the default umask.
+    test_agentsview_private_parent_tightened_first() {
+        local paths="$SCRIPT_DIR/../helpers/agentsview-paths.sh"
+        local setup="$SCRIPT_DIR/../sv-agentsview-setup"
+        if [[ ! -r "$paths" || ! -r "$setup" ]]; then
+            fail "agentsview private parent tightened first" "readable sources" "$paths $setup"
+            return
+        fi
+        # shellcheck source=/dev/null
+        source "$paths"
+        local pi_private subdir
+        pi_private="$(agentsview_field PRIVATE pi || true)"
+        subdir="$(agentsview_field SUBDIR pi || true)"
+        # The declared private dir must actually be a parent of the session dir,
+        # or tightening it protects nothing.
+        if [[ -z "$pi_private" || "$subdir" != "$pi_private/"* ]]; then
+            fail "agentsview private parent tightened first" \
+                "AGENTSVIEW_PRIVATE_pi set and a parent of SUBDIR" \
+                "private=$pi_private subdir=$subdir"
+            return
+        fi
+        local priv_line subdir_line
+        priv_line=$(grep -n 'for private in \$private_list' "$setup" | head -1 | cut -d: -f1 || true)
+        subdir_line=$(grep -n 'for subdir in \$subdir_list' "$setup" | head -1 | cut -d: -f1 || true)
+        if [[ -z "$priv_line" || -z "$subdir_line" ]]; then
+            fail "agentsview private parent tightened first" \
+                "both generated loops present" \
+                "private=$priv_line subdir=$subdir_line"
+            return
+        fi
+        if [[ "$priv_line" -lt "$subdir_line" ]] \
+            && grep -F -- 'chmod 700 "\$priv_full"' "$setup" &>/dev/null \
+            && grep -F -- 'SEARCH_ONLY_RIGHTS="group:$SANDVAULT_GROUP allow search,readattr"' "$setup" &>/dev/null; then
+            pass "agentsview private parent tightened first"
+        else
+            fail "agentsview private parent tightened first" \
+                "private loop before subdir loop, chmod 700 + traverse-only ACE" \
+                "private=$priv_line subdir=$subdir_line"
+        fi
+    }
+    queue_test test_agentsview_private_parent_tightened_first
+
+    # AGENTSVIEW_DEFAULT_* (shell) and DEFAULT_SUBPATHS (Python) hold the same
+    # host-side defaults, but only the Python table is consumed when writing
+    # config.toml. They can drift for pi or any future agent with nothing
+    # catching it, so assert they agree.
+    test_agentsview_default_tables_agree() {
+        local paths="$SCRIPT_DIR/../helpers/agentsview-paths.sh"
+        if [[ ! -r "$paths" ]]; then
+            fail "agentsview default tables agree" "readable agentsview-paths.sh" "$paths"
+            return
+        fi
+        # shellcheck source=/dev/null
+        source "$paths"
+        local agent tomlkey shell_default py_default mismatches=""
+        for agent in "${AGENTSVIEW_AGENTS[@]}"; do
+            tomlkey="$(agentsview_field TOMLKEY "$agent" || true)"
+            shell_default="$(agentsview_field DEFAULT "$agent" || true)"
+            # `|| true`: a python failure here must surface as a mismatch the
+            # test reports, not a pipefail abort of the whole suite.
+            py_default=$(/usr/bin/python3 -c '
+import runpy, sys
+mod = runpy.run_path(sys.argv[1])
+print(mod["DEFAULT_SUBPATHS"].get(sys.argv[2], "<missing>"))
+' "$AGENTSVIEW_CONFIG_SCRIPT" "$tomlkey" 2>/dev/null || true)
+            if [[ "$shell_default" != "$py_default" ]]; then
+                mismatches+="$agent($tomlkey): shell=$shell_default py=$py_default "
+            fi
+        done
+        if [[ -z "$mismatches" ]]; then
+            pass "agentsview default tables agree"
+        else
+            fail "agentsview default tables agree" \
+                "AGENTSVIEW_DEFAULT_* == DEFAULT_SUBPATHS for every agent" \
+                "$mismatches"
+        fi
+    }
+    queue_test test_agentsview_default_tables_agree
 
     ###############################################################################
     # Summary

--- a/sv
+++ b/sv
@@ -408,14 +408,17 @@ install_lightpanda() {
 install_deps () {
     if [[ "$NATIVE_INSTALL" == "true" ]]; then
         # Native install is handled inside the sandbox by guest/home/bin/* scripts;
-        # ensure node is available for npm-based tools (codex, gemini).
+        # ensure node is available for npm-based tools (codex, gemini, pi).
         case "${COMMAND:-}" in
             codex)
                 if [[ ! -x "$SHARED_WORKSPACE/user/.local/bin/codex" && ! -x "$SHARED_WORKSPACE/user/bin/codex" ]]; then
                     ensure_brew_tool "node" "node"
                 fi
                 ;;
-            gemini)
+            gemini|pi)
+                # Both ship as npm bin shims that need node at exec time even
+                # when already staged, so always ensure node (unlike codex's
+                # self-contained binary, which skips it when present).
                 ensure_brew_tool "node" "node"
                 ;;
             *)
@@ -438,6 +441,9 @@ install_deps () {
                 ;;
             gemini)
                 ensure_brew_tool "gemini-cli" "gemini"
+                ;;
+            pi)
+                ensure_brew_tool "pi-coding-agent" "pi"
                 ;;
             *)
                 # No tool installation needed for other commands
@@ -962,11 +968,12 @@ show_help() {
     echo "  co, codex  [PATH]    Open OpenAI Codex in sandvault"
     echo "  o,  opencode [PATH]  Open OpenCode in sandvault"
     echo "  g,  gemini [PATH]    Open Google Gemini in sandvault"
+    echo "  p,  pi     [PATH]    Open pi in sandvault"
     echo "  s, shell   [PATH]    Open shell in sandvault"
     echo "  b, build             Build sandvault"
     echo "  u, uninstall         Remove sandvault; keep shared files"
     echo ""
-    echo "Arguments after -- are passed to the command (claude, codex, opencode, gemini, shell)"
+    echo "Arguments after -- are passed to the command (claude, codex, opencode, gemini, pi, shell)"
     echo ""
     echo "Environment:"
     echo "  SANDVAULT_ARGS       Default arguments (prepended to command line)"
@@ -1092,6 +1099,10 @@ case "${1:-}" in
         ;;
     g|gemini)
         COMMAND=gemini
+        INITIAL_DIR="${2:-}"
+        ;;
+    p|pi)
+        COMMAND=pi
         INITIAL_DIR="${2:-}"
         ;;
     s|shell)
@@ -1760,7 +1771,7 @@ if [[ "$FIX_PERMISSIONS" == "true" ]]; then
     # Fix homebrew symlinks for any installed tools
     # shellcheck disable=SC2310 # brew_shellenv intentionally used in condition
     if brew_shellenv 2>/dev/null; then
-        for tool_cli in claude codex opencode gemini; do
+        for tool_cli in claude codex opencode gemini pi; do
             brew_link="$(brew --prefix)/bin/$tool_cli"
             if [[ -L "$brew_link" ]]; then
                 link_perms=$(/usr/bin/stat -f "%Lp" "$brew_link")

--- a/sv-agentsview-setup
+++ b/sv-agentsview-setup
@@ -85,7 +85,7 @@ agentsview_contamination_check() {
 # Install
 ###############################################################################
 
-# Create the four mirror symlinks under $SV_PRIVATE_DIR/sessions/.
+# Create one mirror symlink per agent under $SV_PRIVATE_DIR/sessions/.
 # Idempotent. Logs and continues on individual failures (warn for tolerated
 # skips like a non-symlink at the path; error for unexpected `ln` failures).
 agentsview_install_symlinks() {
@@ -165,12 +165,38 @@ agentsview_update_config() {
 }
 
 # Write the sandbox-side setup-merge script that runs as the sandvault user
-# during session startup. Each session it ensures the four agent session
+# during session startup. Each session it ensures each agent's session
 # subdirs exist with an inheriting read ACL for the sandvault group, so JSONL
 # files are readable by the host user through the mirror symlinks. No-op
 # unless the host has opted in (state file == enabled).
 write_setup_merge_script() {
     mkdir -p "$SV_PRIVATE_DIR/setup"
+    # Build the subdir list from AGENTSVIEW_AGENTS (the single source of truth
+    # in helpers/agentsview-paths.sh) so this generated script picks up new
+    # agents automatically instead of drifting like a hardcoded list would.
+    # Only this generated script tracks the list; the host-side symlink and
+    # TOML key are still written once, at opt-in.
+    local agent _q _subdir _private subdir_list="" private_list=""
+    for agent in "${AGENTSVIEW_AGENTS[@]}"; do
+        _subdir="$(agentsview_field SUBDIR "$agent")"
+        # An agent listed in AGENTSVIEW_AGENTS with no SUBDIR would emit an
+        # empty element here, and the generated loop would then resolve
+        # "$HOME/" and apply an inheriting group-read ACL to the entire sandbox
+        # home on every session. Fail loudly instead.
+        [[ -n "$_subdir" ]] || abort "agentsview: agent '$agent' has no SUBDIR"
+        printf -v _q '"%s" ' "$_subdir"
+        subdir_list+="$_q"
+        # Expand a private path into every component under $HOME: ".pi/agent"
+        # gives ".pi" and ".pi/agent". mkdir -p creates each one at 0755, so
+        # tightening only the last would leave the parent group-listable, and
+        # the sandbox home is group-owned by the sandvault group.
+        _private="$(agentsview_field PRIVATE "$agent")"
+        while [[ -n "$_private" && "$_private" != "." && "$_private" != "/" ]]; do
+            printf -v _q '"%s" ' "$_private"
+            private_list="$_q$private_list"
+            _private="$(dirname "$_private")"
+        done
+    done
     cat > "$SV_PRIVATE_DIR/setup/agentsview-export" << SETUP_EOF
 #!/bin/bash
 set -Eeuo pipefail
@@ -184,7 +210,23 @@ fi
 # without execute.
 DIR_RIGHTS="group:$SANDVAULT_GROUP allow read,readattr,readextattr,readsecurity,search,list,directory_inherit"
 FILE_INHERIT_RIGHTS="group:$SANDVAULT_GROUP allow read,readattr,readextattr,readsecurity,file_inherit,directory_inherit,only_inherit"
-for subdir in "$AGENTSVIEW_SUBDIR_claude" "$AGENTSVIEW_SUBDIR_codex" "$AGENTSVIEW_SUBDIR_opencode" "$AGENTSVIEW_SUBDIR_gemini"; do
+# Traverse-only: no list, no inherit. Lets the host reach a session directory
+# through a credential-bearing parent without being able to enumerate it.
+SEARCH_ONLY_RIGHTS="group:$SANDVAULT_GROUP allow search,readattr"
+# Credential-bearing parents, tightened before the session dirs are created
+# below so mkdir -p can't leave one at 0755. Order matters: mkdir -p on the
+# session dir would otherwise create the parent first, at the default umask.
+for private in $private_list; do
+    [[ -n "\$private" ]] || continue
+    priv_full="\$HOME/\$private"
+    mkdir -p "\$priv_full"
+    /bin/chmod 700 "\$priv_full" 2>/dev/null || true
+    /bin/chmod +a "\$SEARCH_ONLY_RIGHTS" "\$priv_full" 2>/dev/null || true
+done
+for subdir in $subdir_list; do
+    # Belt and braces with the generator's own check: never let an empty
+    # element resolve to \$HOME itself and ACL the whole sandbox home.
+    [[ -n "\$subdir" ]] || continue
     full="\$HOME/\$subdir"
     mkdir -p "\$full"
     /bin/chmod +a "\$DIR_RIGHTS" "\$full" 2>/dev/null || true
@@ -204,6 +246,21 @@ agentsview_setup() {
 
     if [[ -f "$AGENTSVIEW_STATE_FILE" ]]; then
         trace "agentsview: choice already recorded ($(cat "$AGENTSVIEW_STATE_FILE")); skipping prompt"
+        # A user who opted in before sandvault knew about an agent has no mirror
+        # symlink for it, and no scan path in config.toml. The generated ACL
+        # script tracks AGENTSVIEW_AGENTS, but these two steps run once, at
+        # opt-in. Report the gap: silence here looks identical to success.
+        if [[ "$(cat "$AGENTSVIEW_STATE_FILE")" == "enabled" ]]; then
+            local agent missing=""
+            for agent in "${AGENTSVIEW_AGENTS[@]}"; do
+                [[ -e "$SV_PRIVATE_DIR/sessions/$agent" ]] || missing+="$agent "
+            done
+            if [[ -n "$missing" ]]; then
+                info "agentsview: these agents have no mirror: ${missing% }"
+                info "agentsview: to add them, delete $AGENTSVIEW_STATE_FILE."
+                info "agentsview: then run \`sv-agentsview-setup\` again."
+            fi
+        fi
         return 0
     fi
     if [[ ! -t 0 ]]; then
@@ -236,11 +293,12 @@ agentsview_setup() {
     info "This will:"
     info "  - add read-only symlinks under $SV_PRIVATE_DIR/sessions/"
     info "  - apply read-only ACLs to sandbox agent session dirs"
-    info "  - add four scan paths to $AGENTSVIEW_HOST_CONFIG (with diff confirmation)"
+    info "  - add a scan path per agent to $AGENTSVIEW_HOST_CONFIG (with diff confirmation)"
     info "  - rewrite your agentsview config without preserving comments"
     info ""
-    info "Sandvault won't auto-track new agents agentsview adds in future versions"
-    info "(re-run \`sv-agentsview-setup\` after deleting $AGENTSVIEW_STATE_FILE to refresh)."
+    info "Sandvault does not track new agents automatically. This applies to agents"
+    info "that agentsview adds, and to agents that sandvault adds in a later version."
+    info "To refresh, delete $AGENTSVIEW_STATE_FILE and run this command again."
     printf 'Enable agentsview export? [y/N] '
     local reply
     read -r reply


### PR DESCRIPTION
## Motivation

pi is part of my daily agent rotation now, and I would really like it inside sandvault sandboxes the same way claude, codex, opencode, and gemini already are.

Closes #181.

## Summary

- New `guest/home/bin/pi` wrapper. Binary resolution checks explicit paths only (native npm install under `--native-install`, otherwise the Homebrew prefix, then `~/.local/bin` and `~/.bun/bin`). It deliberately never PATH-searches for `pi`: the wrapper itself lives at `~/bin/pi` ahead of everything else on PATH, so `command -v pi` would resolve the wrapper and exec-loop forever. A regression test locks this in.
- `sv` wiring: `p | pi` dispatch, help text, `install_deps` (`ensure_brew_tool "pi-coding-agent" "pi"`; `sv -N pi` installs from npm inside the sandbox and always ensures node for the bin shim), and `--fix-permissions` coverage.
- The wrapper passes `--approve`. Worth flagging because it is not the analogue of `--dangerously-skip-permissions` / `--yolo`: pi has no permission-bypass concept and runs its tools without prompting regardless. `--approve` skips pi's interactive *project-trust* prompt, so project-local extensions, skills, prompt templates, and themes load without stopping for input. Narrower than the other agents' flags, but still a trust decision, so it is named as one in the README and CHANGELOG rather than filed under "autonomy".
- agentsview session export: pi added to `AGENTSVIEW_AGENTS` (`.pi/agent/sessions`, `pi_dirs`), and the generated setup-merge script now builds its subdir list from that single source of truth instead of a hardcoded four-agent list.
- agentsview session export: pi added to `AGENTSVIEW_AGENTS`, and the generated setup-merge script now builds its subdir list from that single source of truth rather than four hardcoded variables. It aborts instead of emitting an empty element — one would resolve `"$HOME/"` and apply an inheriting group-read ACL to the whole sandbox home every session.
- pi is the first agent whose session path nests under a credential-bearing parent: `auth.json` lives in `~/.pi/agent`. `mkdir -p` would create that parent at 0755 under the default umask, and pi's auth-storage applies 0700 only at creation time — it never chmods an existing directory, so sandvault pre-creating it would leave the credential directory group-listable for the life of the sandbox home. New optional `AGENTSVIEW_PRIVATE_<agent>` field (set only for pi) makes the generated script create it 0700 with a traverse-only ACE before the session-dir loop. `auth.json` itself was always 0600 — this closes directory listing, not file content.
- Existing agentsview opt-in users pick pi up the documented way, by deleting `$SV_PRIVATE_DIR/setup/agentsview-export.state` and re-running `sv-agentsview-setup`. Making that automatic means changing the flow from prompt-once to run-on-every-invocation, which needs a way to decline permanently and a guard against the config writer character-splitting a hand-written scalar. I had that working and took it back out — it's a design change to the export flow, not agent enablement, and it deserves its own PR.
- Tests: help listing, trust/prompt wiring anchored to the exec line, dispatch arm, Homebrew formula and npm package names, agentsview wiring, self-resolution loop guard, setup-merge generation safety, private-parent ordering, and DEFAULT-table parity between the shell and Python sides.
- Docs: README feature list, quick start, agent-flag list, native install, and the agentsview dashboard list. No CHANGELOG entry — every prior change to that file is a release "Bump version to X", and `.github/scripts/patch-changelog` generates the section from commits at release time.

## Test plan

- [x] `./scripts/tests` and `./tests/tests` run on this branch, rebased onto `main` at v1.26.0. Every pi and agentsview test passes. Both suites do exit non-zero, and identically so on a pristine `main` worktree I ran as a control — two sandbox-integration tests need an unlocked login keychain, and the browser/simulator suites need Chrome and a simulator runtime this machine doesn't have. Nothing on the branch moves either suite.
- [x] `shellcheck -x` clean at warning severity and above on every file touched; the branch adds no new findings at any severity.

---
*Authored by [Jesse Robbins](https://jesserobbins.com) (@jesserobbins)*
