### PR TITLE
Warm up Codex host helper

### DIFF
--- a/guest/home/bin/codex
+++ b/guest/home/bin/codex
@@ -6,7 +6,13 @@ trap 'echo >&2 "${BASH_SOURCE[0]}: line $LINENO: $BASH_COMMAND: exitcode $?"' ER
 source "$(dirname "${BASH_SOURCE[0]}")/sv-tool-prompts.sh"
 
 unset CODEX
-if [[ "${SV_NATIVE_INSTALL:-}" == "true" ]]; then
+if [[ -n "${SHARED_WORKSPACE:-}" && -x "$SHARED_WORKSPACE/user/.local/bin/codex" ]]; then
+    CODEX="$SHARED_WORKSPACE/user/.local/bin/codex"
+elif [[ -n "${SHARED_WORKSPACE:-}" && -x "$SHARED_WORKSPACE/user/bin/codex" ]]; then
+    CODEX="$SHARED_WORKSPACE/user/bin/codex"
+elif [[ -x "$HOME/.local/bin/codex" ]]; then
+    CODEX="$HOME/.local/bin/codex"
+elif [[ "${SV_NATIVE_INSTALL:-}" == "true" ]]; then
     # Install under ~/.local (NOT a dir named "node_modules" at $HOME): a
     # "node_modules" at $HOME trips Bun's ancestor-walk heuristic and disables
     # Bun auto-install for the whole $HOME subtree (webcoyote/sandvault#169).

--- a/scripts/tests
+++ b/scripts/tests
@@ -357,6 +357,20 @@ run_tests() {
     }
     queue_test test_opencode_wrapper_uses_skip_permissions
 
+    test_codex_code_mode_host_warmup_present() {
+        if grep -F -- "codex-code-mode-host" "$SV_BASE" &>/dev/null \
+            && grep -F -- "Warming up codex-code-mode-host" "$SV_BASE" &>/dev/null \
+            && grep -F -- "com.apple.quarantine" "$SV_BASE" &>/dev/null \
+            && ! grep -F -- "xattr -d com.apple.quarantine" "$SV_BASE" &>/dev/null; then
+            pass "codex code-mode host warmup is present"
+        else
+            fail "codex code-mode host warmup is present" \
+                "codex-code-mode-host quarantine warmup without xattr removal" \
+                "$SV_BASE"
+        fi
+    }
+    queue_test test_codex_code_mode_host_warmup_present
+
     # Unknown option
     test_unknown_option() {
         local output

--- a/sv
+++ b/sv
@@ -305,6 +305,17 @@ ensure_brew_tool() {
             abort "$cli_name is quarantined and failed to warm up. Run '$brew_bin --help' once as $HOST_USER and try again."
         fi
     fi
+    if [[ "$NESTED" == "false" && "$cli_name" == "codex" ]]; then
+        local code_mode_host_bin
+        code_mode_host_bin="$(dirname "$brew_bin")/codex-code-mode-host"
+        if [[ -x "$code_mode_host_bin" ]] \
+            && /usr/bin/xattr -p com.apple.quarantine "$code_mode_host_bin" &>/dev/null; then
+            debug "Warming up codex-code-mode-host outside sandvault..."
+            if ! "$code_mode_host_bin" --version &>/dev/null; then
+                abort "codex-code-mode-host is quarantined and failed to warm up. Run '$code_mode_host_bin --version' once as $HOST_USER and try again."
+            fi
+        fi
+    fi
 
     # Fix homebrew symlink permissions only when explicitly requested.
     # sv doesn't own these symlinks (homebrew creates them), so only
@@ -716,11 +727,11 @@ start_ios_simulator() {
         > "$IOS_BRIDGE_LOG_FILE" 2>&1 &
     IOS_BRIDGE_PID=$!
 
-    # Wait for the bridge to report its port (up to 15 seconds). Generous
+    # Wait for the bridge to report its port (up to 60 seconds). Generous
     # because CI runners under load can be slow to start Python processes.
     local port=""
     local i
-    for (( i=0; i<150; i++ )); do
+    for (( i=0; i<600; i++ )); do
         if ! kill -0 "$IOS_BRIDGE_PID" 2>/dev/null; then
             IOS_BRIDGE_PID=""
             stop_ios_simulator
@@ -735,7 +746,7 @@ start_ios_simulator() {
 
     if [[ -z "$port" ]]; then
         stop_ios_simulator
-        abort "iOS bridge did not report a port within 15 seconds. Check $IOS_BRIDGE_LOG_FILE."
+        abort "iOS bridge did not report a port within 60 seconds. Check $IOS_BRIDGE_LOG_FILE."
     fi
 
     IOS_BRIDGE_PORT="$port"


### PR DESCRIPTION
- Exercise `codex-code-mode-host` when Homebrew leaves it quarantined
- Match existing Codex warm-up behaviour without mutating xattrs directly
- Prefer sandbox-local Codex shims so tests can replace the binary
- Give the iOS bridge longer to announce its port under CI load

Replaces #180 (this is a rebase of that one)

