### PR TITLE
sv-clone: make deploy keys opt-in via -k/-w flags

### DIFF
--- a/scripts/tests
+++ b/scripts/tests
@@ -654,6 +654,74 @@ run_tests() {
         "$bash_path" "$SV_CLONE_BASE" "$@"
     }
 
+    # Create a fake `gh` on PATH that records every invocation (to
+    # GH_STUB_LOG) and tracks a minimal deploy-key registry (in
+    # GH_STUB_STATE, set by the caller as env vars), so the -k/-w code paths
+    # can be exercised without a real GitHub token or network access.
+    make_gh_stub() {
+        local stub_dir="$1"
+        mkdir -p "$stub_dir"
+        cat > "$stub_dir/gh" <<'STUB_EOF'
+#!/bin/bash
+echo "$@" >> "$GH_STUB_LOG"
+case "$1" in
+    auth)
+        exit 0
+        ;;
+    repo)
+        case "$2" in
+            deploy-key)
+                case "$3" in
+                    list)
+                        shift 3
+                        jqexpr=""
+                        while [[ $# -gt 0 ]]; do
+                            case "$1" in
+                                --jq) jqexpr="$2"; shift 2 ;;
+                                *) shift ;;
+                            esac
+                        done
+                        title="$(printf '%s' "$jqexpr" | sed -n 's/.*title == "\([^"]*\)".*/\1/p')"
+                        awk -F'\t' -v t="$title" '$1==t{print $2"\t"$3}' "$GH_STUB_STATE" 2>/dev/null
+                        exit 0
+                        ;;
+                    add)
+                        shift 3
+                        shift # public key path, unused by the stub
+                        title=""
+                        write=false
+                        while [[ $# -gt 0 ]]; do
+                            case "$1" in
+                                --title) title="$2"; shift 2 ;;
+                                --allow-write) write=true; shift ;;
+                                -R) shift 2 ;;
+                                *) shift ;;
+                            esac
+                        done
+                        newid="$(date +%s%N)"
+                        ro=true
+                        $write && ro=false
+                        grep -v -F "$(printf '%s\t' "$title")" "$GH_STUB_STATE" > "$GH_STUB_STATE.tmp" 2>/dev/null || true
+                        mv "$GH_STUB_STATE.tmp" "$GH_STUB_STATE"
+                        printf '%s\t%s\t%s\n' "$title" "$newid" "$ro" >> "$GH_STUB_STATE"
+                        exit 0
+                        ;;
+                    delete)
+                        id="$4"
+                        awk -F'\t' -v i="$id" '$2!=i' "$GH_STUB_STATE" > "$GH_STUB_STATE.tmp" 2>/dev/null || true
+                        mv "$GH_STUB_STATE.tmp" "$GH_STUB_STATE"
+                        exit 0
+                        ;;
+                esac
+                ;;
+        esac
+        ;;
+esac
+exit 1
+STUB_EOF
+        chmod +x "$stub_dir/gh"
+    }
+
     # Test cloning a local repository via sv-clone and wiring remotes.
     test_sv_clone_local() {
         local src_repository
@@ -823,6 +891,294 @@ run_tests() {
         fi
     }
     queue_test test_sv_clone_help
+
+    # Clone tests below share the same destination repo name ("sandvault")
+    # and race if parallelized.
+    wait_for_all_running_tests
+
+    # Test that sv-clone does not generate a deploy key or touch the origin
+    # remote unless -k/-w is given.
+    test_sv_clone_no_flag_no_deploy_key() {
+        local clone_path key_file origin_after output status
+        local https_repository="https://github.com/webcoyote/sandvault.git"
+
+        clone_path="$SHARED_WORKSPACE/repos/sandvault"
+        key_file="$SHARED_WORKSPACE/_sandvault/.ssh/deploy_sandvault"
+
+        sv_cmd s -- rm -rf "$clone_path" >/dev/null 2>&1
+        sv_cmd s -- rm -f "$key_file" "$key_file.pub" >/dev/null 2>&1
+
+        set +e
+        output=$(sv_clone_cmd "$https_repository" -- --no-build shell -- true 2>&1)
+        status=$?
+        set -e
+        if [[ "$status" -ne 0 ]]; then
+            fail "sv-clone default clone generates no deploy key" "exit 0" "$status | $output"
+            return
+        fi
+
+        origin_after=$(git -C "$clone_path" config remote.origin.url 2>/dev/null || true)
+        if [[ "$origin_after" != "$https_repository" ]]; then
+            fail "sv-clone default clone leaves origin untouched" "$https_repository" "$origin_after"
+            return
+        fi
+
+        if [[ -f "$key_file" ]]; then
+            fail "sv-clone default clone generates no deploy key" "no key file" "$key_file exists"
+            return
+        fi
+
+        pass "sv-clone default clone generates no deploy key and leaves origin untouched"
+        sv_cmd s -- rm -rf "$clone_path" >/dev/null 2>&1
+    }
+    queue_test test_sv_clone_no_flag_no_deploy_key
+    wait_for_all_running_tests
+
+    # Test that -k generates a read-only deploy key, rewrites the origin to
+    # SSH, does not request write access, and is idempotent on re-run.
+    test_sv_clone_dash_k_read_only() {
+        local clone_path key_file stub_dir log_file state_file
+        local https_repository="https://github.com/webcoyote/sandvault.git"
+        local output status origin_after ssh_command add_line
+
+        clone_path="$SHARED_WORKSPACE/repos/sandvault"
+        key_file="$SHARED_WORKSPACE/_sandvault/.ssh/deploy_sandvault"
+        stub_dir="$(mktemp -d)"
+        log_file="$(mktemp)"
+        state_file="$(mktemp)"
+
+        sv_cmd s -- rm -rf "$clone_path" >/dev/null 2>&1
+        sv_cmd s -- rm -f "$key_file" "$key_file.pub" >/dev/null 2>&1
+
+        make_gh_stub "$stub_dir"
+        export GH_STUB_LOG="$log_file"
+        export GH_STUB_STATE="$state_file"
+
+        set +e
+        output=$(PATH="$stub_dir:$PATH" sv_clone_cmd -k "$https_repository" -- --no-build shell -- true 2>&1)
+        status=$?
+        set -e
+        if [[ "$status" -ne 0 ]]; then
+            fail "sv-clone -k generates a read-only deploy key" "exit 0" "$status | $output"
+            return
+        fi
+
+        if [[ ! -f "$key_file" ]]; then
+            fail "sv-clone -k generates a deploy key file" "$key_file exists" "not found"
+            return
+        fi
+
+        origin_after=$(git -C "$clone_path" config remote.origin.url 2>/dev/null || true)
+        if [[ "$origin_after" != "git@github.com:webcoyote/sandvault.git" ]]; then
+            fail "sv-clone -k rewrites origin to SSH" "git@github.com:webcoyote/sandvault.git" "$origin_after"
+            return
+        fi
+
+        ssh_command=$(git -C "$clone_path" config core.sshCommand 2>/dev/null || true)
+        if [[ "$ssh_command" != *"$key_file"* ]]; then
+            fail "sv-clone -k configures core.sshCommand" "*$key_file*" "$ssh_command"
+            return
+        fi
+
+        add_line=$(grep -F 'deploy-key add' "$log_file" | tail -1)
+        if [[ "$add_line" == *"--allow-write"* ]]; then
+            fail "sv-clone -k does not request write access" "no --allow-write" "$add_line"
+            return
+        fi
+
+        # Re-running -k against a repo whose key is already registered
+        # (per the stub's state file) should still (re)activate the SSH
+        # origin and sshCommand — idempotent, not a silent no-op. Remove
+        # only the local clone (not the deploy key or stub state) first, so
+        # this re-run takes the fresh-HTTPS-clone path rather than the
+        # existing-repo fetch path: that fetch would use the real `ssh`
+        # binary against real github.com, which never actually received
+        # this test's key (only the fake `gh` was told about it), and would
+        # fail on real auth rather than exercising the code we're testing.
+        sv_cmd s -- rm -rf "$clone_path" >/dev/null 2>&1
+
+        set +e
+        output=$(PATH="$stub_dir:$PATH" sv_clone_cmd -k "$https_repository" -- --no-build shell -- true 2>&1)
+        status=$?
+        set -e
+        if [[ "$status" -ne 0 ]]; then
+            fail "sv-clone -k re-run is idempotent" "exit 0" "$status | $output"
+            return
+        fi
+        origin_after=$(git -C "$clone_path" config remote.origin.url 2>/dev/null || true)
+        ssh_command=$(git -C "$clone_path" config core.sshCommand 2>/dev/null || true)
+        if [[ "$origin_after" != "git@github.com:webcoyote/sandvault.git" || -z "$ssh_command" ]]; then
+            fail "sv-clone -k re-run reactivates existing key" "origin rewritten + sshCommand set" "$origin_after | $ssh_command"
+            return
+        fi
+
+        pass "sv-clone -k generates read-only key, rewrites origin, is idempotent"
+        sv_cmd s -- rm -rf "$clone_path" >/dev/null 2>&1
+        rm -rf "$stub_dir" "$log_file" "$state_file"
+    }
+    queue_test test_sv_clone_dash_k_read_only
+    wait_for_all_running_tests
+
+    # Test that -w generates a deploy key with write access.
+    test_sv_clone_dash_w_write() {
+        local clone_path key_file stub_dir log_file state_file
+        local https_repository="https://github.com/webcoyote/sandvault.git"
+        local output status add_line
+
+        clone_path="$SHARED_WORKSPACE/repos/sandvault"
+        key_file="$SHARED_WORKSPACE/_sandvault/.ssh/deploy_sandvault"
+        stub_dir="$(mktemp -d)"
+        log_file="$(mktemp)"
+        state_file="$(mktemp)"
+
+        sv_cmd s -- rm -rf "$clone_path" >/dev/null 2>&1
+        sv_cmd s -- rm -f "$key_file" "$key_file.pub" >/dev/null 2>&1
+
+        make_gh_stub "$stub_dir"
+        export GH_STUB_LOG="$log_file"
+        export GH_STUB_STATE="$state_file"
+
+        set +e
+        output=$(PATH="$stub_dir:$PATH" sv_clone_cmd -w "$https_repository" -- --no-build shell -- true 2>&1)
+        status=$?
+        set -e
+        if [[ "$status" -ne 0 ]]; then
+            fail "sv-clone -w requests write access" "exit 0" "$status | $output"
+            return
+        fi
+
+        add_line=$(grep -F 'deploy-key add' "$log_file" | tail -1)
+        if [[ "$add_line" != *"--allow-write"* ]]; then
+            fail "sv-clone -w requests write access" "--allow-write present" "$add_line"
+            return
+        fi
+
+        pass "sv-clone -w requests write access from GitHub"
+        sv_cmd s -- rm -rf "$clone_path" >/dev/null 2>&1
+        rm -rf "$stub_dir" "$log_file" "$state_file"
+    }
+    queue_test test_sv_clone_dash_w_write
+    wait_for_all_running_tests
+
+    # Test that re-running with -w over an existing -k clone upgrades the
+    # deploy key to write access (delete + re-add) without regenerating the
+    # local private key.
+    test_sv_clone_dash_w_upgrades_read_only_key() {
+        local clone_path key_file stub_dir log_file state_file
+        local https_repository="https://github.com/webcoyote/sandvault.git"
+        local output status key_hash_before key_hash_after
+
+        clone_path="$SHARED_WORKSPACE/repos/sandvault"
+        key_file="$SHARED_WORKSPACE/_sandvault/.ssh/deploy_sandvault"
+        stub_dir="$(mktemp -d)"
+        log_file="$(mktemp)"
+        state_file="$(mktemp)"
+
+        sv_cmd s -- rm -rf "$clone_path" >/dev/null 2>&1
+        sv_cmd s -- rm -f "$key_file" "$key_file.pub" >/dev/null 2>&1
+
+        make_gh_stub "$stub_dir"
+        export GH_STUB_LOG="$log_file"
+        export GH_STUB_STATE="$state_file"
+
+        set +e
+        output=$(PATH="$stub_dir:$PATH" sv_clone_cmd -k "$https_repository" -- --no-build shell -- true 2>&1)
+        status=$?
+        set -e
+        if [[ "$status" -ne 0 || ! -f "$key_file" ]]; then
+            fail "sv-clone -k seeds a read-only key for the upgrade test" "exit 0 + key file" "$status | $output"
+            return
+        fi
+        key_hash_before=$(shasum "$key_file" | awk '{print $1}')
+
+        # Remove only the local clone (not the deploy key or stub state)
+        # before re-running with -w, so this run takes the fresh-HTTPS-clone
+        # path rather than the existing-repo fetch path — see the comment in
+        # test_sv_clone_dash_k_read_only for why that fetch path can't work
+        # against a key this test only registered with the fake `gh`.
+        sv_cmd s -- rm -rf "$clone_path" >/dev/null 2>&1
+
+        : > "$log_file"
+        set +e
+        output=$(PATH="$stub_dir:$PATH" sv_clone_cmd -w "$https_repository" -- --no-build shell -- true 2>&1)
+        status=$?
+        set -e
+        if [[ "$status" -ne 0 ]]; then
+            fail "sv-clone -w upgrades an existing read-only key" "exit 0" "$status | $output"
+            return
+        fi
+
+        key_hash_after=$(shasum "$key_file" | awk '{print $1}')
+        if [[ "$key_hash_before" != "$key_hash_after" ]]; then
+            fail "sv-clone -w upgrade reuses the local keypair" "$key_hash_before" "$key_hash_after"
+            return
+        fi
+
+        if ! grep -q 'deploy-key delete' "$log_file"; then
+            fail "sv-clone -w upgrade deletes the old read-only key" "deploy-key delete recorded" "$(cat "$log_file")"
+            return
+        fi
+        if ! grep -F 'deploy-key add' "$log_file" | grep -q -- '--allow-write'; then
+            fail "sv-clone -w upgrade re-adds the key with write access" "--allow-write recorded" "$(cat "$log_file")"
+            return
+        fi
+
+        pass "sv-clone -w upgrades an existing read-only key to write access"
+        sv_cmd s -- rm -rf "$clone_path" >/dev/null 2>&1
+        rm -rf "$stub_dir" "$log_file" "$state_file"
+    }
+    queue_test test_sv_clone_dash_w_upgrades_read_only_key
+    wait_for_all_running_tests
+
+    # Test that -k with no gh CLI on PATH prints the public key for manual
+    # setup and does not rewrite the origin to SSH.
+    test_sv_clone_dash_k_no_gh() {
+        local clone_path key_file no_gh_path output status origin_after
+        local https_repository="https://github.com/webcoyote/sandvault.git"
+        local dir path_dirs
+
+        clone_path="$SHARED_WORKSPACE/repos/sandvault"
+        key_file="$SHARED_WORKSPACE/_sandvault/.ssh/deploy_sandvault"
+
+        sv_cmd s -- rm -rf "$clone_path" >/dev/null 2>&1
+        sv_cmd s -- rm -f "$key_file" "$key_file.pub" >/dev/null 2>&1
+
+        # Build a PATH identical to the current one but with any directory
+        # that also provides `gh` removed, so every other tool sv-clone
+        # needs (git, ssh-keygen, mkdir, ...) is still found normally.
+        no_gh_path=""
+        IFS=':' read -ra path_dirs <<< "$PATH"
+        for dir in "${path_dirs[@]}"; do
+            if [[ ! -x "$dir/gh" ]]; then
+                no_gh_path="${no_gh_path:+$no_gh_path:}$dir"
+            fi
+        done
+
+        set +e
+        output=$(PATH="$no_gh_path" sv_clone_cmd -k "$https_repository" -- --no-build shell -- true 2>&1)
+        status=$?
+        set -e
+        if [[ "$status" -ne 0 ]]; then
+            fail "sv-clone -k without gh prints manual instructions" "exit 0" "$status | $output"
+            return
+        fi
+
+        if [[ "$output" != *"add manually"* ]]; then
+            fail "sv-clone -k without gh prints manual instructions" "*add manually*" "$output"
+            return
+        fi
+
+        origin_after=$(git -C "$clone_path" config remote.origin.url 2>/dev/null || true)
+        if [[ "$origin_after" != "$https_repository" ]]; then
+            fail "sv-clone -k without gh leaves origin untouched" "$https_repository" "$origin_after"
+            return
+        fi
+
+        pass "sv-clone -k without gh prints manual instructions and leaves origin untouched"
+        sv_cmd s -- rm -rf "$clone_path" >/dev/null 2>&1
+    }
+    queue_test test_sv_clone_dash_k_no_gh
+    wait_for_all_running_tests
 
     fi # end sv-clone tests (non-SSH only)
 

--- a/sv-clone
+++ b/sv-clone
@@ -9,15 +9,21 @@
 # After cloning, it launches an sv session in the cloned repository.
 #
 # Usage:
-#   sv-clone [-v|-vv|-vvv] <URL|PATH> [-- sv-args ...]
+#   sv-clone [-v|-vv|-vvv] [options] <URL|PATH> [-- sv-args ...]
+#
+# Options:
+#   -k, --repo-deploy-key    Create a deploy key for this repo and upload it
+#                            to GitHub (read-only)
+#   -w, --allow-repo-write   Allow the deploy key to push to this repo
+#                            (implies --repo-deploy-key)
 #
 # Everything after -- is passed directly to sv (options, command, args).
 # If no command is given, defaults to "shell".
 #
 # Examples:
 #   sv-clone https://github.com/org/repo.git
-#   sv-clone git@github.com:org/repo.git -- claude
-#   sv-clone ~/projects/myrepo -- -b shell -- echo hello
+#   sv-clone -k git@github.com:org/repo.git -- claude
+#   sv-clone -w ~/projects/myrepo -- -b shell -- echo hello
 set -Eeuo pipefail
 trap 'echo >&2 "${BASH_SOURCE[0]}: line $LINENO: $BASH_COMMAND: exitcode $?"' ERR
 
@@ -75,6 +81,8 @@ git_repo() {
 ###############################################################################
 CLONE_REPOSITORY=""
 SV_ARGS=()
+DEPLOY_KEY=false
+DEPLOY_KEY_WRITE=false
 
 if [[ $# -lt 1 ]]; then
     echo >&2 "Usage: $(basename "$0") [OPTIONS] <URL|PATH> [-- sv-args ...]"
@@ -100,16 +108,29 @@ while [[ $# -gt 0 ]]; do
             ((SV_VERBOSE+=3)) || true
             shift
             ;;
+        -k|--repo-deploy-key)
+            DEPLOY_KEY=true
+            shift
+            ;;
+        -w|--allow-repo-write)
+            DEPLOY_KEY=true
+            DEPLOY_KEY_WRITE=true
+            shift
+            ;;
         -h|--help)
-            echo "Usage: $(basename "$0") [-v|-vv|-vvv] <URL|PATH> [-- sv-args ...]"
+            echo "Usage: $(basename "$0") [-v|-vv|-vvv] [options] <URL|PATH> [-- sv-args ...]"
             echo ""
             echo "Clone a git repository into the sandvault shared workspace and"
             echo "launch an sv session there."
             echo ""
             echo "Options:"
-            echo "  -v, --verbose   Enable verbose output"
-            echo "  -vv / -vvv      More verbose / even more verbose"
-            echo "  -h, --help      Show this help message"
+            echo "  -k, --repo-deploy-key   Create a deploy key for this repo and upload it"
+            echo "                          to GitHub (read-only)"
+            echo "  -w, --allow-repo-write  Allow the deploy key to push to this repo"
+            echo "                          (implies --repo-deploy-key)"
+            echo "  -v, --verbose           Enable verbose output"
+            echo "  -vv / -vvv              More verbose / even more verbose"
+            echo "  -h, --help              Show this help message"
             echo ""
             echo "Everything after -- is passed directly to sv."
             echo "If no sv command is given, defaults to 'shell'."
@@ -181,6 +202,12 @@ readonly REPOSITORY_SOURCE_URL
 readonly CLONE_SOURCE="${LOCAL_REPOSITORY:-$REPOSITORY_SOURCE_URL}"
 readonly REPO_DIR="$SHARED_WORKSPACE/repos/$REPOSITORY_NAME"
 
+# Fixed regardless of whether -k/-w is given this run, so a later re-run
+# (with or without those flags) can tell whether an earlier run already
+# activated a deploy key for this repo — see the fetch step below.
+readonly DEPLOY_KEY_PRIV="$SV_PRIVATE_DIR/.ssh/deploy_${REPOSITORY_NAME}"
+readonly DEPLOY_KEY_PUB="$DEPLOY_KEY_PRIV.pub"
+
 debug "Repository: $REPOSITORY_NAME"
 debug "Source URL: $REPOSITORY_SOURCE_URL"
 debug "Clone from: $CLONE_SOURCE"
@@ -212,46 +239,51 @@ info "Repository ready at $REPO_DIR"
 
 
 ###############################################################################
-# Deploy key — auto-generated for GitHub repositories
+# Deploy key — opt-in for GitHub repositories
 ###############################################################################
-# The sandvault user has no credentials. For any GitHub repo (cloned via SSH,
-# HTTPS, or local path), generate a per-repo ED25519 deploy key so the sandbox
-# can push/pull. The origin remote is rewritten to SSH so the deploy key works.
-# Keys are stored in $SV_PRIVATE_DIR/.ssh/ — outside the repo working tree,
-# accessible to both users via group ACLs.
+# The sandvault user has no credentials. When -k/--repo-deploy-key (or
+# -w/--allow-repo-write) is given, generate a per-repo ED25519 deploy key so
+# the sandbox can pull (and, with -w, push). The key is uploaded read-only
+# unless -w is given: sandvault runs agents in bypass-permissions mode, so
+# write access is never granted implicitly. The origin remote is rewritten to
+# SSH only once the key is confirmed usable, so a repo that cloned fine over
+# HTTPS doesn't lose the ability to fetch if the upload fails. Keys are stored
+# in $SV_PRIVATE_DIR/.ssh/ — outside the repo working tree, accessible to both
+# users via group ACLs.
 
-# Extract owner/repo from origin URL (works for SSH, HTTPS, and local clones
-# whose origin points to GitHub)
-# A missing origin is fine (local clones may have none); tolerate failure.
-# shellcheck disable=SC2310 # set -e suppression is intended: we want the fallback
-ORIGIN_URL="$(git_repo remote get-url origin 2>/dev/null)" || ORIGIN_URL=""
 GITHUB_REPO_PATH=""
-if [[ -n "$ORIGIN_URL" ]]; then
-    # Normalize: strip protocol/host prefixes and .git suffix
-    GITHUB_REPO_PATH="$ORIGIN_URL"
-    GITHUB_REPO_PATH="${GITHUB_REPO_PATH#https://github.com/}"
-    GITHUB_REPO_PATH="${GITHUB_REPO_PATH#http://github.com/}"
-    GITHUB_REPO_PATH="${GITHUB_REPO_PATH#ssh://git@github.com/}"
-    GITHUB_REPO_PATH="${GITHUB_REPO_PATH#git@github.com:}"
-    GITHUB_REPO_PATH="${GITHUB_REPO_PATH#git@github.com/}"
-    GITHUB_REPO_PATH="${GITHUB_REPO_PATH%.git}"
+if [[ "$DEPLOY_KEY" == true ]]; then
+    # Extract owner/repo from origin URL (works for SSH, HTTPS, and local
+    # clones whose origin points to GitHub). A missing origin is fine (local
+    # clones may have none); tolerate failure.
+    # shellcheck disable=SC2310 # set -e suppression is intended: we want the fallback
+    ORIGIN_URL="$(git_repo remote get-url origin 2>/dev/null)" || ORIGIN_URL=""
+    if [[ -n "$ORIGIN_URL" ]]; then
+        # Normalize: strip protocol/host prefixes and .git suffix
+        GITHUB_REPO_PATH="$ORIGIN_URL"
+        GITHUB_REPO_PATH="${GITHUB_REPO_PATH#https://github.com/}"
+        GITHUB_REPO_PATH="${GITHUB_REPO_PATH#http://github.com/}"
+        GITHUB_REPO_PATH="${GITHUB_REPO_PATH#ssh://git@github.com/}"
+        GITHUB_REPO_PATH="${GITHUB_REPO_PATH#git@github.com:}"
+        GITHUB_REPO_PATH="${GITHUB_REPO_PATH#git@github.com/}"
+        GITHUB_REPO_PATH="${GITHUB_REPO_PATH%.git}"
 
-    # If it still looks like a full URL or local path, it's not GitHub
-    if [[ "$GITHUB_REPO_PATH" == *"://"* || "$GITHUB_REPO_PATH" == /* ]]; then
-        GITHUB_REPO_PATH=""
-    fi
+        # If it still looks like a full URL or local path, it's not GitHub
+        if [[ "$GITHUB_REPO_PATH" == *"://"* || "$GITHUB_REPO_PATH" == /* ]]; then
+            GITHUB_REPO_PATH=""
+        fi
 
-    # Validate the result looks like owner/repo
-    if [[ -n "$GITHUB_REPO_PATH" && ! "$GITHUB_REPO_PATH" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
-        GITHUB_REPO_PATH=""
+        # Validate the result looks like owner/repo
+        if [[ -n "$GITHUB_REPO_PATH" && ! "$GITHUB_REPO_PATH" =~ ^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$ ]]; then
+            GITHUB_REPO_PATH=""
+        fi
     fi
 fi
 
 if [[ -n "$GITHUB_REPO_PATH" ]]; then
-    DEPLOY_KEY_NAME="deploy_${REPOSITORY_NAME}"
     DEPLOY_KEY_DIR="$SV_PRIVATE_DIR/.ssh"
-    DEPLOY_KEY_PRIV="$DEPLOY_KEY_DIR/$DEPLOY_KEY_NAME"
-    DEPLOY_KEY_PUB="$DEPLOY_KEY_PRIV.pub"
+    DEPLOY_KEY_TITLE="sandvault-deploy-${REPOSITORY_NAME}@${HOSTNAME}"
+    DEPLOY_SSH_URL="git@github.com:${GITHUB_REPO_PATH}.git"
 
     if [[ ! -f "$DEPLOY_KEY_PRIV" ]]; then
         mkdir -p "$DEPLOY_KEY_DIR"
@@ -260,38 +292,77 @@ if [[ -n "$GITHUB_REPO_PATH" ]]; then
             -f "$DEPLOY_KEY_PRIV" \
             -N "" \
             -q \
-            -C "sandvault-deploy-${REPOSITORY_NAME}@${HOSTNAME}"
+            -C "$DEPLOY_KEY_TITLE"
         info "Generated deploy key for $REPOSITORY_NAME"
     else
         debug "Deploy key already exists for $REPOSITORY_NAME"
     fi
 
-    # Rewrite origin to SSH so the deploy key is used for push/pull
-    DEPLOY_SSH_URL="git@github.com:${GITHUB_REPO_PATH}.git"
-    if [[ "$ORIGIN_URL" != "$DEPLOY_SSH_URL" ]]; then
-        git_repo remote set-url origin "$DEPLOY_SSH_URL"
-        debug "Rewrote origin to $DEPLOY_SSH_URL"
-    fi
+    # Only rewrite the origin to SSH and configure core.sshCommand once the
+    # key is confirmed usable. Doing this unconditionally would strand a
+    # public HTTPS clone if the upload below fails or gh is unavailable.
+    activate_deploy_key() {
+        if [[ "$ORIGIN_URL" != "$DEPLOY_SSH_URL" ]]; then
+            git_repo remote set-url origin "$DEPLOY_SSH_URL"
+            debug "Rewrote origin to $DEPLOY_SSH_URL"
+        fi
+        git_repo config core.sshCommand \
+            "ssh -i '$DEPLOY_KEY_PRIV' -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
+    }
 
-    # Configure this repo to use its deploy key (persists in .git/config)
-    git_repo config core.sshCommand \
-        "ssh -i '$DEPLOY_KEY_PRIV' -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new"
-
-    # Upload deploy key to GitHub via gh CLI, or show it for manual addition
+    DEPLOY_KEY_ACCESS=""
     if command -v gh &>/dev/null && gh auth status &>/dev/null; then
-        if gh repo deploy-key add "$DEPLOY_KEY_PUB" \
-            --title "sandvault-deploy-${REPOSITORY_NAME}@${HOSTNAME}" \
-            -R "$GITHUB_REPO_PATH" 2>/dev/null; then
-            info "Deploy key added to $GITHUB_REPO_PATH (read-only)"
+        # Look up any deploy key already registered under this title. GitHub
+        # can't change a deploy key's permission level in place, so upgrading
+        # read-only to write requires delete + re-add.
+        EXISTING_KEY_LINE="$(gh repo deploy-key list -R "$GITHUB_REPO_PATH" \
+            --json id,title,readOnly \
+            --jq ".[] | select(.title == \"$DEPLOY_KEY_TITLE\") | [.id, .read_only] | @tsv" \
+            2>/dev/null)" || EXISTING_KEY_LINE=""
+
+        if [[ -n "$EXISTING_KEY_LINE" ]]; then
+            EXISTING_KEY_ID="${EXISTING_KEY_LINE%%$'\t'*}"
+            EXISTING_KEY_READONLY="${EXISTING_KEY_LINE##*$'\t'}"
+            if [[ "$DEPLOY_KEY_WRITE" == true && "$EXISTING_KEY_READONLY" == "true" ]]; then
+                if gh repo deploy-key delete "$EXISTING_KEY_ID" -R "$GITHUB_REPO_PATH" 2>/dev/null \
+                    && gh repo deploy-key add "$DEPLOY_KEY_PUB" \
+                        --title "$DEPLOY_KEY_TITLE" --allow-write \
+                        -R "$GITHUB_REPO_PATH" 2>/dev/null; then
+                    activate_deploy_key
+                    DEPLOY_KEY_ACCESS="write"
+                    info "Deploy key for $GITHUB_REPO_PATH upgraded to write access"
+                else
+                    warn "Could not upgrade deploy key to write access (check repo permissions)"
+                fi
+            else
+                # Already registered with sufficient access; just make sure
+                # this clone is configured to use it (idempotent re-run).
+                activate_deploy_key
+                [[ "$EXISTING_KEY_READONLY" == "true" ]] && DEPLOY_KEY_ACCESS="read-only" || DEPLOY_KEY_ACCESS="write"
+                debug "Deploy key already registered on $GITHUB_REPO_PATH ($DEPLOY_KEY_ACCESS)"
+            fi
         else
-            warn "Could not add deploy key via gh CLI (may already exist or check repo permissions)"
-            echo ""
-            info "Deploy key for $REPOSITORY_NAME — add manually:"
-            echo "──────────────────────────────────────────────────────────"
-            cat "$DEPLOY_KEY_PUB"
-            echo "──────────────────────────────────────────────────────────"
-            info "https://github.com/$GITHUB_REPO_PATH/settings/keys"
-            echo ""
+            GH_ADD_ARGS=(--title "$DEPLOY_KEY_TITLE" -R "$GITHUB_REPO_PATH")
+            [[ "$DEPLOY_KEY_WRITE" == true ]] && GH_ADD_ARGS+=(--allow-write)
+            if gh repo deploy-key add "$DEPLOY_KEY_PUB" "${GH_ADD_ARGS[@]}" 2>/dev/null; then
+                activate_deploy_key
+                if [[ "$DEPLOY_KEY_WRITE" == true ]]; then
+                    DEPLOY_KEY_ACCESS="write"
+                    info "Deploy key added to $GITHUB_REPO_PATH (write access enabled)"
+                else
+                    DEPLOY_KEY_ACCESS="read-only"
+                    info "Deploy key added to $GITHUB_REPO_PATH (read-only)"
+                fi
+            else
+                warn "Could not add deploy key via gh CLI (check repo permissions)"
+                echo ""
+                info "Deploy key for $REPOSITORY_NAME — add manually:"
+                echo "──────────────────────────────────────────────────────────"
+                cat "$DEPLOY_KEY_PUB"
+                echo "──────────────────────────────────────────────────────────"
+                info "https://github.com/$GITHUB_REPO_PATH/settings/keys"
+                echo ""
+            fi
         fi
     else
         echo ""
@@ -302,6 +373,14 @@ if [[ -n "$GITHUB_REPO_PATH" ]]; then
         info "https://github.com/$GITHUB_REPO_PATH/settings/keys"
         echo ""
     fi
+
+    if [[ -n "$DEPLOY_KEY_ACCESS" ]]; then
+        if [[ "$DEPLOY_KEY_ACCESS" == "write" ]]; then
+            info "Sandbox access to $GITHUB_REPO_PATH: pull ✓  push ✓"
+        else
+            info "Sandbox access to $GITHUB_REPO_PATH: pull ✓  push ✗  (enable: sv-clone -w <url>)"
+        fi
+    fi
 fi
 
 
@@ -310,10 +389,13 @@ fi
 ###############################################################################
 # Done here, after deploy-key setup, so the fetch runs with an sshCommand we
 # pass explicitly rather than one a guest may have written into .git/config
-# (git_repo neutralizes core.sshCommand for exactly that reason).
+# (git_repo neutralizes core.sshCommand for exactly that reason). Checked by
+# key-file presence rather than this run's -k/-w flags, since a prior run may
+# have activated the key (rewriting origin to SSH) even though this run
+# didn't pass either flag — the origin still needs the key to fetch.
 if [[ "$REPO_EXISTED" == true ]]; then
     debug "Fetching existing repository..."
-    if [[ -n "${DEPLOY_KEY_PRIV:-}" && -f "$DEPLOY_KEY_PRIV" ]]; then
+    if [[ -f "$DEPLOY_KEY_PRIV" ]]; then
         git_repo -c "core.sshCommand=ssh -i '$DEPLOY_KEY_PRIV' -o IdentitiesOnly=yes -o StrictHostKeyChecking=accept-new" \
             fetch "${LOCAL_REPOSITORY:-origin}"
     else


### PR DESCRIPTION
## Motivation

#129 asked for an opt-in `--deploy-key` flag, but #139 shipped it always-on for every GitHub clone, and #170 only fixed the write-access part of that — a key still gets generated and uploaded (read-only) for every single clone whether you want sandbox push/pull credentials or not. Sandvault runs agents in bypass-permissions mode, so I don't think a key should exist at all unless it's asked for, and it definitely shouldn't get write access without an explicit, separate ask.

## Summary

- `-k`/`--repo-deploy-key` generates a per-repo deploy key and uploads it read-only; no flag means no key, no origin rewrite, no gh calls at all.
- `-w`/`--allow-repo-write` implies `-k` and grants write access.
- The origin is only rewritten to SSH once the key is confirmed usable (uploaded, or manual setup shown), so a plain HTTPS clone can't lose fetch access if `gh` is missing or the upload fails.
- Re-running `-w` over an existing `-k` clone upgrades the key in place (GitHub can't change a key's permission level, so it's delete + re-add, reusing the same local keypair) rather than requiring a fresh clone.
- Fixed a re-run bug this surfaced along the way: the deferred fetch for an already-cloned repo checked *this run's* `-k`/`-w` flags rather than whether a deploy key file already exists on disk, so a later flagless re-run of a repo that an earlier `-k`/`-w` had activated would try to fetch with a neutralized `core.sshCommand` and fail outright.

## Test plan

- [x] `./scripts/validate` — added 5 new `sv-clone` test cases (default clone generates no key, `-k` read-only + idempotent re-run, `-w` write access, `-w` upgrading an existing read-only key, `-k` with no `gh` on PATH) alongside the 5 existing ones; all pass. The flag/branch logic is exercised against a local `gh` stub (recording invocations against a small in-memory key registry) since CI has no real GitHub token with deploy-key permissions.
- [x] Verified the real `gh repo deploy-key list/add/delete` command contract by hand against a repo I own (`--jq` requires `--json`; the list field is `readOnly` in the selector but `read_only` in the actual output) — the stub mirrors what I confirmed live, not a guess.
- [ ] Live end-to-end smoke test (`-k` then `-w` against a real throwaway repo, confirming GitHub actually grants push after the upgrade) — not done here since it requires mutating a real repo's deploy keys; happy to run this before merge if wanted.

---
*Authored by [Jesse Robbins](https://jesserobbins.com)*