### PR TITLE
Release v1.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable user-facing changes to SandVault are documented in this file.
 
+## [1.26.0] - 2026-07-30
+
+### Fixed
+
+- Support login keychains on macOS 27 ([#191](https://github.com/webcoyote/sandvault/pull/191)) — thanks @MikeMcQuaid!
+
+### Thanks to 1 contributor!
+
+- [@MikeMcQuaid](https://github.com/MikeMcQuaid)
+
 ## [1.25.0] - 2026-07-26
 
 ### Added

--- a/sv
+++ b/sv
@@ -124,7 +124,7 @@ fi
 ###############################################################################
 # Resources
 ###############################################################################
-readonly VERSION="1.25.0"
+readonly VERSION="1.26.0"
 
 # Re-entrancy detection: if SV_SESSION_ID is already set, we're already in sandvault.
 NESTED=false


### PR DESCRIPTION
## [1.26.0] - 2026-07-30

### Fixed

- Support login keychains on macOS 27 ([#191](https://github.com/webcoyote/sandvault/pull/191)) — thanks @MikeMcQuaid!

### Thanks to 1 contributor!

- [@MikeMcQuaid](https://github.com/MikeMcQuaid)