### PR TITLE
Bump bump-homebrew-formula-action v3 → v4.2

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -9,7 +9,7 @@ jobs:
     name: Bump Homebrew Formula
     runs-on: ubuntu-latest
     steps:
-      - uses: mislav/bump-homebrew-formula-action@v3
+      - uses: mislav/bump-homebrew-formula-action@v4.2
         with:
           formula-name: sandvault
         env:


### PR DESCRIPTION
Fixes 'unexpected HTTP 303 response' failure. GitHub now returns HTTP 303 (not 302) for tarball redirects; v4.2 accepts any 3xx redirect (mislav/bump-homebrew-formula-action#340).