### PR TITLE
Avoid login keychain corruption after reboot

### DIFF
--- a/guest/home/configure
+++ b/guest/home/configure
@@ -49,19 +49,48 @@ abort () {
 # TODO: I guess the sv script could call this configure script directly
 # with the password the first time instead of it being called from .zshrc
 ###############################################################################
-# Explicitly specify the path to avoid confusion with the host user;
-# - security dump-keychain                 => host user
-# - security dump-keychain $LOGIN_KEYCHAIN => sandvault user
-LOGIN_KEYCHAIN="$HOME/Library/Keychains/login.keychain-db"
-if [[ ! -f "$LOGIN_KEYCHAIN" ]]; then
+# Use a dedicated keychain because macOS changes the login keychain password
+# to the account password after rebooting.
+SANDVAULT_KEYCHAIN="$HOME/Library/Keychains/sandvault.keychain-db"
+if [[ ! -f "$SANDVAULT_KEYCHAIN" ]]; then
     debug "Creating keychain without password..."
-    security create-keychain -p '' "$LOGIN_KEYCHAIN"
+    security create-keychain -p '' "$SANDVAULT_KEYCHAIN"
 fi
 
 # Unlock the keychain and disable auto-lock to avoid password dialogs
 debug "Unlocking keychain..."
-security unlock-keychain -p '' "$LOGIN_KEYCHAIN" &>/dev/null || true
-security set-keychain-settings "$LOGIN_KEYCHAIN"
+security unlock-keychain -p '' "$SANDVAULT_KEYCHAIN" &>/dev/null || true
+security set-keychain-settings "$SANDVAULT_KEYCHAIN"
+security default-keychain -s "$SANDVAULT_KEYCHAIN"
+security list-keychains -s "$SANDVAULT_KEYCHAIN" /Library/Keychains/System.keychain
+
+LEGACY_LOGIN_KEYCHAIN="$HOME/Library/Keychains/login.keychain-db"
+CLAUDE_KEYCHAIN_SERVICE="Claude Code-credentials"
+if [[ -f "$LEGACY_LOGIN_KEYCHAIN" ]] \
+    && ! security find-generic-password \
+        -a "$USER" -s "$CLAUDE_KEYCHAIN_SERVICE" \
+        "$SANDVAULT_KEYCHAIN" &>/dev/null \
+    && security find-generic-password \
+        -a "$USER" -s "$CLAUDE_KEYCHAIN_SERVICE" \
+        "$LEGACY_LOGIN_KEYCHAIN" &>/dev/null
+then
+    debug "Migrating Claude Code credentials..."
+    if security unlock-keychain -p '' "$LEGACY_LOGIN_KEYCHAIN" &>/dev/null \
+        && CLAUDE_CREDENTIAL=$(security find-generic-password \
+            -a "$USER" -s "$CLAUDE_KEYCHAIN_SERVICE" -w \
+            "$LEGACY_LOGIN_KEYCHAIN" 2>/dev/null) \
+        && printf '%s\n%s\n' "$CLAUDE_CREDENTIAL" "$CLAUDE_CREDENTIAL" \
+            | security add-generic-password -U \
+                -a "$USER" -s "$CLAUDE_KEYCHAIN_SERVICE" -w &>/dev/null
+    then
+        debug "Migrated Claude Code credentials"
+    else
+        warn "Could not migrate Claude Code credentials from $LEGACY_LOGIN_KEYCHAIN."
+        warn "Run 'sv claude' and sign in again."
+        warn "Keep the legacy keychain until all affected tools have been reauthenticated."
+    fi
+    unset CLAUDE_CREDENTIAL
+fi
 
 
 ###############################################################################

--- a/scripts/tests
+++ b/scripts/tests
@@ -387,7 +387,7 @@ run_tests() {
         test_home="$(mktemp -d)"
         stub_dir="$(mktemp -d)"
         mkdir -p "$test_home/Library/Keychains"
-        touch "$test_home/Library/Keychains/login.keychain-db"
+        touch "$test_home/Library/Keychains/sandvault.keychain-db"
 
         cat > "$stub_dir/security" <<'EOF'
 #!/bin/bash
@@ -420,6 +420,120 @@ EOF
         fi
     }
     queue_test test_configure_tolerates_already_unlocked_keychain
+
+    test_configure_uses_dedicated_keychain() {
+        local output status stub_dir test_home
+        test_home="$(mktemp -d)"
+        stub_dir="$(mktemp -d)"
+        mkdir -p "$test_home/Library/Keychains"
+        touch "$test_home/Library/Keychains/login.keychain-db"
+
+        cat > "$stub_dir/security" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$*" >> "$SECURITY_LOG"
+case "$1" in
+    create-keychain)
+        touch "$4"
+        ;;
+    find-generic-password)
+        if [[ "$*" == *"sandvault.keychain-db"* ]]; then
+            exit 44
+        elif [[ "$*" == *" -w "* ]]; then
+            printf 'migrated credential'
+        fi
+        ;;
+    add-generic-password)
+        IFS= read -r credential
+        IFS= read -r confirmation
+        if [[ "$credential" == "migrated credential" \
+            && "$confirmation" == "$credential" ]]; then
+            touch "$MIGRATION_MARKER"
+        fi
+        ;;
+esac
+EOF
+        cat > "$stub_dir/defaults" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+        chmod +x "$stub_dir/security" "$stub_dir/defaults"
+
+        set +e
+        output=$(HOME="$test_home" \
+            PATH="$stub_dir:/usr/bin:/bin:/usr/sbin:/sbin" \
+            MIGRATION_MARKER="$test_home/migrated" \
+            SECURITY_LOG="$test_home/security.log" \
+            SHARED_WORKSPACE="" \
+            SV_VERBOSE=0 \
+            "$SCRIPT_DIR/../guest/home/configure" 2>&1)
+        status=$?
+        set -e
+
+        if [[ "$status" -eq 0 \
+            && -f "$test_home/Library/Keychains/sandvault.keychain-db" \
+            && -f "$test_home/Library/Keychains/login.keychain-db" \
+            && -f "$test_home/migrated" \
+            && $(grep -Fc "default-keychain -s $test_home/Library/Keychains/sandvault.keychain-db" "$test_home/security.log") -eq 1 \
+            && $(grep -Fc "list-keychains -s $test_home/Library/Keychains/sandvault.keychain-db /Library/Keychains/System.keychain" "$test_home/security.log") -eq 1 ]]; then
+            pass "configure uses a dedicated keychain"
+        else
+            fail "configure uses a dedicated keychain" \
+                "dedicated default keychain and search list" \
+                "$status | $output | $(cat "$test_home/security.log" 2>/dev/null || true)"
+        fi
+        rm -rf "$test_home" "$stub_dir"
+    }
+    queue_test test_configure_uses_dedicated_keychain
+
+    test_configure_warns_when_keychain_migration_fails() {
+        local output status stub_dir test_home
+        test_home="$(mktemp -d)"
+        stub_dir="$(mktemp -d)"
+        mkdir -p "$test_home/Library/Keychains"
+        touch "$test_home/Library/Keychains/login.keychain-db"
+
+        cat > "$stub_dir/security" <<'EOF'
+#!/bin/bash
+case "$1" in
+    create-keychain)
+        touch "$4"
+        ;;
+    find-generic-password)
+        [[ "$*" != *"sandvault.keychain-db"* ]] || exit 44
+        ;;
+    unlock-keychain)
+        [[ "$*" != *"login.keychain-db"* ]] || exit 51
+        ;;
+esac
+exit 0
+EOF
+        cat > "$stub_dir/defaults" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+        chmod +x "$stub_dir/security" "$stub_dir/defaults"
+
+        set +e
+        output=$(HOME="$test_home" \
+            PATH="$stub_dir:/usr/bin:/bin:/usr/sbin:/sbin" \
+            SHARED_WORKSPACE="" \
+            SV_VERBOSE=0 \
+            "$SCRIPT_DIR/../guest/home/configure" 2>&1)
+        status=$?
+        set -e
+        rm -rf "$test_home" "$stub_dir"
+
+        if [[ "$status" -eq 0 \
+            && "$output" == *"Could not migrate Claude Code credentials"* \
+            && "$output" == *"Run 'sv claude' and sign in again"* \
+            && "$output" == *"Keep the legacy keychain until all affected tools have been reauthenticated"* ]]; then
+            pass "configure warns when keychain migration fails"
+        else
+            fail "configure warns when keychain migration fails" \
+                "manual reauthentication and preservation steps" "$status | $output"
+        fi
+    }
+    queue_test test_configure_warns_when_keychain_migration_fails
 
     # Mirror the opencode test for pi: assert the wrapper wires the
     # project-trust flag (--approve, which skips pi's interactive trust prompt;


### PR DESCRIPTION
Fixes #206

Sandvault now uses a dedicated `sandvault.keychain-db` instead of the macOS-managed `login.keychain-db`.

This prevents macOS 26.6 and later from changing the keychain password during a reboot, which previously left the Sandvault user unable to unlock its keychain and caused security prompts when starting agents such as Claude Code.

Existing Claude Code credentials are migrated when the legacy keychain is still accessible. If automatic migration is not possible, Sandvault preserves the old keychain and provides manual recovery instructions.

## Problem

Sandvault creates its user with a randomly generated account password but previously created `login.keychain-db` with an empty keychain password.

The random account password is required for macOS user and SSH setup but is not retained because Sandvault uses key-based authentication and passwordless user switching.

Recent macOS security changes treat `login.keychain-db` specially. After a reboot, macOS can associate the login keychain with the account password rather than its original empty password.

Sandvault subsequently tries to unlock the keychain using:

```sh
security unlock-keychain -p '' login.keychain-db
```

Once macOS has changed the expected password, the empty password no longer works. Because the randomly generated account password is unavailable, the keychain cannot be unlocked and applications display a security prompt.

The existing workaround was destructive and had to be repeated after each reboot:

```sh
sudo rm -rf /Users/sandvault-<user>/Library/Keychains/login.keychain-db sv build --rebuild
```

## Implementation

### Use a dedicated keychain

The Sandvault user now creates:

`~/Library/Keychains/sandvault.keychain-db`

Unlike `login.keychain-db`, this is a normal custom keychain and is not subject to macOS login-password synchronisation.

On each Sandvault session, the configuration script:

1. Creates the dedicated keychain if it does not exist.
2. Unlocks it using the empty Sandvault keychain password.
3. Disables automatic locking and timeouts.
4. Makes it the default user keychain.
5. Replaces the active search list with the Sandvault keychain and the system keychain.

Removing the legacy login keychain from the active search list prevents applications from finding it and displaying a password prompt after a reboot.

The legacy file is not deleted.

### Preserve existing Claude Code authentication

Changing the default keychain without migration would require every existing Claude Code user to sign in again.

During configuration, Sandvault therefore checks whether:

- the legacy login.keychain-db exists;
- the new keychain does not already contain Claude Code-credentials; and
- the legacy keychain contains that credential.

If those conditions are met, Sandvault attempts to unlock the legacy keychain non-interactively and copy the Claude Code credential into the new default keychain.

The destination check makes migration idempotent and avoids overwriting a credential that Claude Code has already stored in the new keychain.

### Handle migration failures

Automatic migration is only attempted when the old keychain can be unlocked without user interaction. This avoids recreating the security popup that this change is intended to fix.

If macOS has already made the old keychain inaccessible, configuration continues with the new keychain and prints a warning explaining how to recover:

Could not migrate Claude Code credentials from <legacy keychain>. Run 'sv claude' and sign in again. Keep the legacy keychain until all affected tools have been reauthenticated.

The legacy keychain remains on disk so users do not lose potentially recoverable credentials.

## Security considerations

Credential values are not printed or written to temporary files.

The migration reads the credential using `security` through stdin. It is not placed in command-line arguments, which prevents it from being exposed through process listings.

Migration is deliberately limited to the known Claude Code generic-password item. Copying arbitrary keychain entries would risk changing their application ACLs. For example, browser safe-storage entries are tied to specific signed applications and cannot be copied safely using the generic security CLI flow.

The legacy keychain is preserved rather than automatically deleted.

## Manual verification

Recommended verification on macOS 26.6 or later:

1. Start with an existing Sandvault installation where Claude Code is authenticated.
2. Install this change and run `sv claude`.
3. Confirm that Claude Code remains authenticated when the legacy keychain is accessible.
4. Confirm that the default keychain is `~/Library/Keychains/sandvault.keychain-db`.
5. Reboot the Mac.
6. Run `sv claude` again.
7. Confirm that no macOS security prompt appears.
8. Confirm that Claude Code can still read and update its credentials.

## Scope

This change migrates Claude Code credentials because Claude Code is the supported agent known to use the macOS keychain.

Other keychain entries, particularly browser safe-storage entries, are left in the preserved legacy keychain because migrating them without their original application ACLs could introduce prompts or weaken access controls.