### PR TITLE
Avoid login keychain corruption after reboot

### DIFF
--- a/guest/home/configure
+++ b/guest/home/configure
@@ -49,19 +49,48 @@ abort () {
 # TODO: I guess the sv script could call this configure script directly
 # with the password the first time instead of it being called from .zshrc
 ###############################################################################
-# Explicitly specify the path to avoid confusion with the host user;
-# - security dump-keychain                 => host user
-# - security dump-keychain $LOGIN_KEYCHAIN => sandvault user
-LOGIN_KEYCHAIN="$HOME/Library/Keychains/login.keychain-db"
-if [[ ! -f "$LOGIN_KEYCHAIN" ]]; then
+# Use a dedicated keychain because macOS changes the login keychain password
+# to the account password after rebooting.
+SANDVAULT_KEYCHAIN="$HOME/Library/Keychains/sandvault.keychain-db"
+if [[ ! -f "$SANDVAULT_KEYCHAIN" ]]; then
     debug "Creating keychain without password..."
-    security create-keychain -p '' "$LOGIN_KEYCHAIN"
+    security create-keychain -p '' "$SANDVAULT_KEYCHAIN"
 fi
 
 # Unlock the keychain and disable auto-lock to avoid password dialogs
 debug "Unlocking keychain..."
-security unlock-keychain -p '' "$LOGIN_KEYCHAIN" &>/dev/null || true
-security set-keychain-settings "$LOGIN_KEYCHAIN"
+security unlock-keychain -p '' "$SANDVAULT_KEYCHAIN" &>/dev/null || true
+security set-keychain-settings "$SANDVAULT_KEYCHAIN"
+security default-keychain -s "$SANDVAULT_KEYCHAIN"
+security list-keychains -s "$SANDVAULT_KEYCHAIN" /Library/Keychains/System.keychain
+
+LEGACY_LOGIN_KEYCHAIN="$HOME/Library/Keychains/login.keychain-db"
+CLAUDE_KEYCHAIN_SERVICE="Claude Code-credentials"
+if [[ -f "$LEGACY_LOGIN_KEYCHAIN" ]] \
+    && ! security find-generic-password \
+        -a "$USER" -s "$CLAUDE_KEYCHAIN_SERVICE" \
+        "$SANDVAULT_KEYCHAIN" &>/dev/null \
+    && security find-generic-password \
+        -a "$USER" -s "$CLAUDE_KEYCHAIN_SERVICE" \
+        "$LEGACY_LOGIN_KEYCHAIN" &>/dev/null
+then
+    debug "Migrating Claude Code credentials..."
+    if security unlock-keychain -p '' "$LEGACY_LOGIN_KEYCHAIN" &>/dev/null \
+        && CLAUDE_CREDENTIAL=$(security find-generic-password \
+            -a "$USER" -s "$CLAUDE_KEYCHAIN_SERVICE" -w \
+            "$LEGACY_LOGIN_KEYCHAIN" 2>/dev/null) \
+        && printf '%s\n%s\n' "$CLAUDE_CREDENTIAL" "$CLAUDE_CREDENTIAL" \
+            | security add-generic-password -U \
+                -a "$USER" -s "$CLAUDE_KEYCHAIN_SERVICE" -w &>/dev/null
+    then
+        debug "Migrated Claude Code credentials"
+    else
+        warn "Could not migrate Claude Code credentials from $LEGACY_LOGIN_KEYCHAIN."
+        warn "Run 'sv claude' and sign in again."
+        warn "Keep the legacy keychain until all affected tools have been reauthenticated."
+    fi
+    unset CLAUDE_CREDENTIAL
+fi
 
 
 ###############################################################################

--- a/guest/home/configure
+++ b/guest/home/configure
@@ -61,8 +61,18 @@ fi
 debug "Unlocking keychain..."
 security unlock-keychain -p '' "$SANDVAULT_KEYCHAIN" &>/dev/null || true
 security set-keychain-settings "$SANDVAULT_KEYCHAIN"
-security default-keychain -s "$SANDVAULT_KEYCHAIN"
-security list-keychains -s "$SANDVAULT_KEYCHAIN" /Library/Keychains/System.keychain
+# Replace the search list with only the sandvault keychain: "-s" overwrites the
+# list rather than appending, so this evicts login.keychain-db and stops lookups
+# from reaching it (which is what triggers the unlock dialog after a reboot).
+# System.keychain is deliberately omitted because the sandbox profile denies
+# reads under /Library/Keychains.
+#
+# Neither call is fatal: a keychain failure should degrade this session, not
+# abort configure before the $HOME rsync and setup scripts below.
+security default-keychain -s "$SANDVAULT_KEYCHAIN" \
+    || warn "Could not set default keychain to $SANDVAULT_KEYCHAIN"
+security list-keychains -s "$SANDVAULT_KEYCHAIN" \
+    || warn "Could not set keychain search list to $SANDVAULT_KEYCHAIN"
 
 LEGACY_LOGIN_KEYCHAIN="$HOME/Library/Keychains/login.keychain-db"
 CLAUDE_KEYCHAIN_SERVICE="Claude Code-credentials"
@@ -81,7 +91,8 @@ then
             "$LEGACY_LOGIN_KEYCHAIN" 2>/dev/null) \
         && printf '%s\n%s\n' "$CLAUDE_CREDENTIAL" "$CLAUDE_CREDENTIAL" \
             | security add-generic-password -U \
-                -a "$USER" -s "$CLAUDE_KEYCHAIN_SERVICE" -w &>/dev/null
+                -a "$USER" -s "$CLAUDE_KEYCHAIN_SERVICE" -w \
+                "$SANDVAULT_KEYCHAIN" &>/dev/null
     then
         debug "Migrated Claude Code credentials"
     else

--- a/scripts/tests
+++ b/scripts/tests
@@ -387,7 +387,7 @@ run_tests() {
         test_home="$(mktemp -d)"
         stub_dir="$(mktemp -d)"
         mkdir -p "$test_home/Library/Keychains"
-        touch "$test_home/Library/Keychains/login.keychain-db"
+        touch "$test_home/Library/Keychains/sandvault.keychain-db"
 
         cat > "$stub_dir/security" <<'EOF'
 #!/bin/bash
@@ -420,6 +420,120 @@ EOF
         fi
     }
     queue_test test_configure_tolerates_already_unlocked_keychain
+
+    test_configure_uses_dedicated_keychain() {
+        local output status stub_dir test_home
+        test_home="$(mktemp -d)"
+        stub_dir="$(mktemp -d)"
+        mkdir -p "$test_home/Library/Keychains"
+        touch "$test_home/Library/Keychains/login.keychain-db"
+
+        cat > "$stub_dir/security" <<'EOF'
+#!/bin/bash
+printf '%s\n' "$*" >> "$SECURITY_LOG"
+case "$1" in
+    create-keychain)
+        touch "$4"
+        ;;
+    find-generic-password)
+        if [[ "$*" == *"sandvault.keychain-db"* ]]; then
+            exit 44
+        elif [[ "$*" == *" -w "* ]]; then
+            printf 'migrated credential'
+        fi
+        ;;
+    add-generic-password)
+        IFS= read -r credential
+        IFS= read -r confirmation
+        if [[ "$credential" == "migrated credential" \
+            && "$confirmation" == "$credential" ]]; then
+            touch "$MIGRATION_MARKER"
+        fi
+        ;;
+esac
+EOF
+        cat > "$stub_dir/defaults" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+        chmod +x "$stub_dir/security" "$stub_dir/defaults"
+
+        set +e
+        output=$(HOME="$test_home" \
+            PATH="$stub_dir:/usr/bin:/bin:/usr/sbin:/sbin" \
+            MIGRATION_MARKER="$test_home/migrated" \
+            SECURITY_LOG="$test_home/security.log" \
+            SHARED_WORKSPACE="" \
+            SV_VERBOSE=0 \
+            "$SCRIPT_DIR/../guest/home/configure" 2>&1)
+        status=$?
+        set -e
+
+        if [[ "$status" -eq 0 \
+            && -f "$test_home/Library/Keychains/sandvault.keychain-db" \
+            && -f "$test_home/Library/Keychains/login.keychain-db" \
+            && -f "$test_home/migrated" \
+            && $(grep -Fc "default-keychain -s $test_home/Library/Keychains/sandvault.keychain-db" "$test_home/security.log") -eq 1 \
+            && $(grep -Fc "list-keychains -s $test_home/Library/Keychains/sandvault.keychain-db /Library/Keychains/System.keychain" "$test_home/security.log") -eq 1 ]]; then
+            pass "configure uses a dedicated keychain"
+        else
+            fail "configure uses a dedicated keychain" \
+                "dedicated default keychain and search list" \
+                "$status | $output | $(cat "$test_home/security.log" 2>/dev/null || true)"
+        fi
+        rm -rf "$test_home" "$stub_dir"
+    }
+    queue_test test_configure_uses_dedicated_keychain
+
+    test_configure_warns_when_keychain_migration_fails() {
+        local output status stub_dir test_home
+        test_home="$(mktemp -d)"
+        stub_dir="$(mktemp -d)"
+        mkdir -p "$test_home/Library/Keychains"
+        touch "$test_home/Library/Keychains/login.keychain-db"
+
+        cat > "$stub_dir/security" <<'EOF'
+#!/bin/bash
+case "$1" in
+    create-keychain)
+        touch "$4"
+        ;;
+    find-generic-password)
+        [[ "$*" != *"sandvault.keychain-db"* ]] || exit 44
+        ;;
+    unlock-keychain)
+        [[ "$*" != *"login.keychain-db"* ]] || exit 51
+        ;;
+esac
+exit 0
+EOF
+        cat > "$stub_dir/defaults" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+        chmod +x "$stub_dir/security" "$stub_dir/defaults"
+
+        set +e
+        output=$(HOME="$test_home" \
+            PATH="$stub_dir:/usr/bin:/bin:/usr/sbin:/sbin" \
+            SHARED_WORKSPACE="" \
+            SV_VERBOSE=0 \
+            "$SCRIPT_DIR/../guest/home/configure" 2>&1)
+        status=$?
+        set -e
+        rm -rf "$test_home" "$stub_dir"
+
+        if [[ "$status" -eq 0 \
+            && "$output" == *"Could not migrate Claude Code credentials"* \
+            && "$output" == *"Run 'sv claude' and sign in again"* \
+            && "$output" == *"Keep the legacy keychain until all affected tools have been reauthenticated"* ]]; then
+            pass "configure warns when keychain migration fails"
+        else
+            fail "configure warns when keychain migration fails" \
+                "manual reauthentication and preservation steps" "$status | $output"
+        fi
+    }
+    queue_test test_configure_warns_when_keychain_migration_fails
 
     # Mirror the opencode test for pi: assert the wrapper wires the
     # project-trust flag (--approve, which skips pi's interactive trust prompt;

--- a/scripts/tests
+++ b/scripts/tests
@@ -474,7 +474,8 @@ EOF
             && -f "$test_home/Library/Keychains/login.keychain-db" \
             && -f "$test_home/migrated" \
             && $(grep -Fc "default-keychain -s $test_home/Library/Keychains/sandvault.keychain-db" "$test_home/security.log") -eq 1 \
-            && $(grep -Fc "list-keychains -s $test_home/Library/Keychains/sandvault.keychain-db /Library/Keychains/System.keychain" "$test_home/security.log") -eq 1 ]]; then
+            && $(grep -Fc "list-keychains -s $test_home/Library/Keychains/sandvault.keychain-db" "$test_home/security.log") -eq 1 \
+            && $(grep -Fc "/Library/Keychains/System.keychain" "$test_home/security.log") -eq 0 ]]; then
             pass "configure uses a dedicated keychain"
         else
             fail "configure uses a dedicated keychain" \
@@ -484,6 +485,58 @@ EOF
         rm -rf "$test_home" "$stub_dir"
     }
     queue_test test_configure_uses_dedicated_keychain
+
+    # configure runs under "set -Eeuo pipefail", so an unguarded security
+    # failure would abort the script before the $HOME rsync and the setup
+    # scripts that follow it. A keychain that cannot be made default must
+    # degrade the session, not break it.
+    test_configure_survives_keychain_setup_failure() {
+        local output status stub_dir test_home
+        test_home="$(mktemp -d)"
+        stub_dir="$(mktemp -d)"
+        mkdir -p "$test_home/Library/Keychains"
+
+        cat > "$stub_dir/security" <<'EOF'
+#!/bin/bash
+case "$1" in
+    create-keychain)
+        touch "$4"
+        ;;
+    default-keychain|list-keychains)
+        exit 1
+        ;;
+    find-generic-password)
+        exit 44
+        ;;
+esac
+exit 0
+EOF
+        cat > "$stub_dir/defaults" <<'EOF'
+#!/bin/bash
+exit 0
+EOF
+        chmod +x "$stub_dir/security" "$stub_dir/defaults"
+
+        set +e
+        output=$(HOME="$test_home" \
+            PATH="$stub_dir:/usr/bin:/bin:/usr/sbin:/sbin" \
+            SHARED_WORKSPACE="" \
+            SV_VERBOSE=0 \
+            "$SCRIPT_DIR/../guest/home/configure" 2>&1)
+        status=$?
+        set -e
+        rm -rf "$test_home" "$stub_dir"
+
+        if [[ "$status" -eq 0 \
+            && "$output" == *"Could not set default keychain"* \
+            && "$output" == *"Could not set keychain search list"* ]]; then
+            pass "configure survives keychain setup failure"
+        else
+            fail "configure survives keychain setup failure" \
+                "exit 0 with both warnings" "$status | $output"
+        fi
+    }
+    queue_test test_configure_survives_keychain_setup_failure
 
     test_configure_warns_when_keychain_migration_fails() {
         local output status stub_dir test_home


### PR DESCRIPTION
Supersedes #207. Fixes #206.

Carries @MikeMcQuaid's original fix unchanged, plus three follow-up fixes
from review.

## Changes on top of #207

- **Drop `/Library/Keychains/System.keychain` from the search list.** The
  sandbox profile denies reads under `/Library/Keychains` (`sv:1623-1627`,
  where the comment notes the deny is "load-bearing"), so listing it was
  inert configuration contradicting that deny. Evicting `login.keychain-db`
  is what actually fixes the post-reboot prompt, and that is unchanged.

- **Make `default-keychain` and `list-keychains` non-fatal.** `configure`
  runs under `set -Eeuo pipefail`, so an unguarded failure aborted the
  script before the `$HOME` rsync and the setup scripts that follow
  (`configure:120-157`), turning a keychain problem into a broken session.
  This mirrors the existing `|| true` guard on `unlock-keychain` added in
  #191.

- **Name the destination keychain explicitly on `add-generic-password`.**
  Migration no longer depends on `default-keychain` having succeeded, which
  matters now that the call is non-fatal.

## Tests

Adds `test_configure_survives_keychain_setup_failure`, and asserts
System.keychain is absent from the search list. Both assertions were
confirmed to fail against the pre-fix code.

## Not addressed

- The `-a "$USER"` filter means migration silently skips with no warning if
  Claude Code stored the item under a different account name.
- `README.md:350` still attributes the security popup solely to
  shared-directory ACLs; #206 is a second cause with a different fix.

## Verification caveat

Stub-based tests only — no reboot on macOS 26.6 was performed. The manual
checklist in #207 still applies.