### PR TITLE
Gate version tagging on CI tests passing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
 
   tag-version:
     name: Tag Version
+    needs: test
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
tag-version had no needs:, so it ran in parallel with the macOS test job and pushed the release tag 15s after a merge landed. The Homebrew workflow triggers on that tag, so it could open a homebrew-core PR for a version whose tests had not finished (or had failed).

Add needs: test so the tag is only pushed after the suite passes.