### PR TITLE
feat(agentsview): re-sync export on every run; fix scalar, decline, diff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable user-facing changes to SandVault are documented in this file.
 
+## [Unreleased]
+
+### Fixed
+
+- `sv-agentsview-setup` now re-syncs the agentsview export on every run instead of prompting once and never again. Agents added after you opted in (like `pi`, and any future agent) now get their mirror symlink and scan path automatically on the next run, instead of staying invisible until you deleted the state file and re-ran the whole opt-in. When a new scan path is needed it still shows a diff and asks for confirmation; declining skips that agent permanently, and a hand-edited `config.toml` no longer re-prompts forever because the diff is now compared on parsed values, not rendered text. A scalar value for a managed key (e.g. `claude_project_dirs = "/path"`) is now rejected with a clear error instead of being silently character-split into single characters. ([#194](https://github.com/webcoyote/sandvault/issues/194))
+
 ## [1.28.0] - 2026-08-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable user-facing changes to SandVault are documented in this file.
 
 ### Fixed
 
-- `sv-agentsview-setup` now re-syncs the agentsview export on every run instead of prompting once and never again. Agents added after you opted in (like `pi`, and any future agent) now get their mirror symlink and scan path automatically on the next run, instead of staying invisible until you deleted the state file and re-ran the whole opt-in. When a new scan path is needed it still shows a diff and asks for confirmation; declining skips that agent permanently, and a hand-edited `config.toml` no longer re-prompts forever because the diff is now compared on parsed values, not rendered text. A scalar value for a managed key (e.g. `claude_project_dirs = "/path"`) is now rejected with a clear error instead of being silently character-split into single characters. ([#194](https://github.com/webcoyote/sandvault/issues/194))
+- `sv-agentsview-setup` re-syncs the agentsview export on every run. Before, it prompted once and never again. Agents added after you opted in (for example `pi`) now get their mirror symlink and scan path on the next run. Before, they stayed invisible until you deleted the state file and ran the opt-in again. A new scan path still shows a diff and asks for confirmation. If you decline, that agent is skipped permanently. A hand-edited `config.toml` no longer re-prompts on every run, because the diff is compared on parsed values, not rendered text. A scalar value for a managed key (for example `claude_project_dirs = "/path"`) is now rejected with a clear error. Before, the value was character-split into single characters. ([#194](https://github.com/webcoyote/sandvault/issues/194))
 
 ## [1.28.0] - 2026-08-19
 

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ Explicit command-line arguments are appended after `SANDVAULT_ARGS`, so they are
 sv-agentsview-setup
 ```
 
-You're prompted once, on first run. After that, `sv-agentsview-setup` re-syncs on every run: it installs the mirror symlinks and adds any scan paths that are missing to `~/.agentsview/config.toml`. New agents sandvault adds in a later version show up automatically the next time you run it. When it adds a new scan path it shows a diff and asks for confirmation; decline and that agent is skipped permanently (remove its key from `~sandvault/setup/agentsview-declined.keys` to re-enable).
+You're prompted once, on first run. After that, `sv-agentsview-setup` re-syncs on every run: it installs the mirror symlinks and adds any scan paths that are missing to `~/.agentsview/config.toml`. New agents sandvault adds in a later version show up automatically the next time you run it. When it adds a new scan path it shows a diff and asks for confirmation; decline and that agent is skipped permanently (remove its key from `/Users/Shared/sv-$USER/_sandvault/setup/agentsview-declined.keys` to re-enable).
 
 Then run `agentsview serve` and you'll see your sandvault AI sessions included in the `agentsview` dashboard.
 

--- a/README.md
+++ b/README.md
@@ -249,16 +249,16 @@ Explicit command-line arguments are appended after `SANDVAULT_ARGS`, so they are
 
 ## `agentsview` Integration
 
-[`agentsview`](https://github.com/badlogic/agentsview) is a dashboard that aggregates session history, search, and cost tracking across AI coding agents (Claude Code, Codex, OpenCode, Gemini, pi). If you have agentsview installed on the host, `sv-agentsview-setup` mirrors sandbox session data so it appears alongside your host-side sessions.
+[`agentsview`](https://github.com/badlogic/agentsview) is a dashboard for AI coding agents (Claude Code, Codex, OpenCode, Gemini, pi). It shows session history, search, and cost tracking. If you have agentsview installed on the host, `sv-agentsview-setup` mirrors sandbox session data so that it appears next to your host-side sessions.
 
 ```bash
 # Detect agentsview, prompt to opt in, and configure
 sv-agentsview-setup
 ```
 
-You're prompted once, on first run. After that, `sv-agentsview-setup` re-syncs on every run: it installs the mirror symlinks and adds any scan paths that are missing to `~/.agentsview/config.toml`. New agents sandvault adds in a later version show up automatically the next time you run it. When it adds a new scan path it shows a diff and asks for confirmation; decline and that agent is skipped permanently (remove its key from `/Users/Shared/sv-$USER/_sandvault/setup/agentsview-declined.keys` to re-enable).
+You are prompted once, on the first run. After that, `sv-agentsview-setup` re-syncs on every run. It installs the mirror symlinks and adds the missing scan paths to `~/.agentsview/config.toml`. New agents that sandvault adds in a later release appear the next time you run the command. When a new scan path is added, the command shows a diff and asks for confirmation. If you decline, that agent is skipped permanently. Remove its key from `/Users/Shared/sv-$USER/_sandvault/setup/agentsview-declined.keys` to enable it again.
 
-Then run `agentsview serve` and you'll see your sandvault AI sessions included in the `agentsview` dashboard.
+Then run `agentsview serve`. You will see your sandvault AI sessions in the `agentsview` dashboard.
 
 
 ## Nested sandboxes

--- a/README.md
+++ b/README.md
@@ -256,6 +256,8 @@ Explicit command-line arguments are appended after `SANDVAULT_ARGS`, so they are
 sv-agentsview-setup
 ```
 
+You're prompted once, on first run. After that, `sv-agentsview-setup` re-syncs on every run: it installs the mirror symlinks and adds any scan paths that are missing to `~/.agentsview/config.toml`. New agents sandvault adds in a later version show up automatically the next time you run it. When it adds a new scan path it shows a diff and asks for confirmation; decline and that agent is skipped permanently (remove its key from `~sandvault/setup/agentsview-declined.keys` to re-enable).
+
 Then run `agentsview serve` and you'll see your sandvault AI sessions included in the `agentsview` dashboard.
 
 

--- a/helpers/agentsview-config.py
+++ b/helpers/agentsview-config.py
@@ -56,13 +56,33 @@ def read_config(config_path: str) -> dict:
         sys.exit(3)
 
 
+class ConfigError(Exception):
+    """The existing config has a managed key with a value we won't silently
+    mangle (e.g. a scalar where an array is expected). Surfaced as exit 3,
+    the same code read_config uses for a parse failure, so the caller treats
+    it as a config error to fix rather than a change to apply."""
+
+
 def apply_agents(config: dict, agents: list[tuple[str, str]], home: str) -> dict:
-    """Merge agent mirror paths into config dict. Returns updated dict."""
+    """Merge agent mirror paths into config dict. Returns updated dict.
+
+    Raises ConfigError if a managed key holds a non-list value. A
+    hand-written scalar like ``claude_project_dirs = "/some/path"`` parses
+    fine as TOML, and ``list()`` on a string character-splits it into
+    ``['/', 's', 'o', ...]`` -- a silent, destructive rewrite. Reject it
+    instead, the way read_config already rejects a parse failure.
+    """
     result = dict(config)
     for key, mirror_path in agents:
         if key in result:
-            # Key present: respect the user's array as-is, only ensure mirror is in it.
-            existing = list(result[key])
+            existing = result[key]
+            if not isinstance(existing, list):
+                raise ConfigError(
+                    f"{key} must be an array of paths, got "
+                    f"{type(existing).__name__}: {existing!r}"
+                )
+            # Copy so we never mutate the caller's dict in place.
+            existing = list(existing)
         else:
             # Key absent: agentsview would use its built-in default. Materialize
             # that default explicitly so adding the mirror doesn't replace it.
@@ -260,11 +280,69 @@ def run_self_test() -> None:
         except Exception:
             fail(name, traceback.format_exc())
 
+        # Test 7: A scalar value for a managed key raises ConfigError instead
+        # of being character-split by list(). Pre-existing bug, only reachable
+        # through the one-time opt-in today; re-syncing on every run makes it
+        # reachable every run, so it must fail loudly instead of silently
+        # turning "/some/path" into ['/', 's', 'o', ...].
+        name = "scalar managed key raises ConfigError"
+        try:
+            key = "claude_project_dirs"
+            cfg = {key: "/some/scalar/path"}
+            raised = False
+            try:
+                apply_agents(cfg, [(key, "/mnt/mirror/claude_project_dirs")], home)
+            except ConfigError:
+                raised = True
+            if raised:
+                ok(name)
+            else:
+                fail(name, "ConfigError", "no exception (value would be char-split)")
+        except Exception:
+            fail(name, traceback.format_exc())
+
+        # Test 8: --check semantics when nothing is pending. apply_agents is a
+        # no-op (mirror already present), so updated == config -> exit 0. This
+        # is the case --diff gets wrong on a hand-edited file: comments and
+        # formatting drift make the rendered diff non-empty forever, which
+        # would re-prompt every run even though nothing is actually missing.
+        name = "check: no pending changes (parsed equality)"
+        try:
+            key = "claude_project_dirs"
+            mirror = "/mnt/mirror/claude_project_dirs"
+            existing_default = default_host_path(key, home)
+            cfg = {key: [existing_default, mirror]}
+            updated = apply_agents(cfg, [(key, mirror)], home)
+            if updated == cfg:
+                ok(name)
+            else:
+                fail(name, "apply_agents(config) == config", f"got {updated}")
+        except Exception:
+            fail(name, traceback.format_exc())
+
+        # Test 9: --check semantics when a mirror path is missing. updated !=
+        # config -> exit 1. A missing mirror is the only condition that should
+        # produce a prompt; comment/formatting drift must not.
+        name = "check: pending changes detected (mirror missing)"
+        try:
+            key = "claude_project_dirs"
+            mirror = "/mnt/mirror/claude_project_dirs"
+            existing_default = default_host_path(key, home)
+            cfg = {key: [existing_default]}  # mirror absent
+            updated = apply_agents(cfg, [(key, mirror)], home)
+            if updated != cfg:
+                ok(name)
+            else:
+                fail(name, "apply_agents(config) != config",
+                     "equal (missing mirror not detected)")
+        except Exception:
+            fail(name, traceback.format_exc())
+
     if failures:
         for msg in failures:
             print(msg, file=sys.stderr)
         sys.exit(1)
-    print(f"All {6} self-tests passed.")
+    print("All 9 self-tests passed.")
 
 
 def main() -> None:
@@ -280,6 +358,9 @@ def main() -> None:
                         help="Agent key and mirror path (repeatable)")
 
     mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--check", action="store_true",
+                      help="Exit 0 if no changes are needed, 1 if a mirror path "
+                           "is still missing, 3 on config error (no write)")
     mode.add_argument("--diff", action="store_true",
                       help="Print unified diff of proposed changes")
     mode.add_argument("--write", action="store_true",
@@ -315,8 +396,24 @@ def main() -> None:
             sys.exit(2)
         agents.append((key, mirror_path))
 
-    config = read_config(args.config_path)
-    updated = apply_agents(config, agents, args.home)
+    try:
+        config = read_config(args.config_path)
+        updated = apply_agents(config, agents, args.home)
+    except ConfigError as e:
+        print(f"error: {args.config_path}: {e}", file=sys.stderr)
+        sys.exit(3)
+
+    if args.check:
+        # Compare parsed values, not rendered text. The writer round-trips
+        # through tomllib/tomli_w, so it drops comments and normalizes
+        # formatting; a --diff against a hand-edited file is non-empty forever,
+        # which would re-prompt on every run even when every mirror path is
+        # already present. Comparing the merged dict to the original is immune
+        # to that: exit 0 when the merge is a no-op, 1 when a mirror path is
+        # still missing. (ConfigError is raised inside apply_agents above, so a
+        # scalar managed key exits 3 here before this branch.)
+        sys.exit(0 if updated == config else 1)
+
     new_content = dumps(updated)
 
     if args.diff:

--- a/helpers/agentsview-config.py
+++ b/helpers/agentsview-config.py
@@ -17,11 +17,17 @@ from tomli_w import dumps
 try:
     import tomllib  # Python 3.11+
 except ModuleNotFoundError:
-    from tomli import load as _tomli_load, loads as _tomli_loads
+    from tomli import load as _tomli_load, loads as _tomli_loads, \
+        TOMLDecodeError as _tomli_TOMLDecodeError
 
     class tomllib:
         load = staticmethod(_tomli_load)
         loads = staticmethod(_tomli_loads)
+        # Expose TOMLDecodeError so read_config can catch it on Python < 3.11.
+        # Without this the `except tomllib.TOMLDecodeError` below raises
+        # AttributeError, the process exits 1, and the shell mistakes a parse
+        # failure for a pending change and silently swallows it.
+        TOMLDecodeError = _tomli_TOMLDecodeError
 
 VALID_KEYS = {
     "claude_project_dirs",
@@ -321,8 +327,10 @@ def run_self_test() -> None:
             fail(name, traceback.format_exc())
 
         # Test 9: --check semantics when a mirror path is missing. updated !=
-        # config -> exit 1. A missing mirror is the only condition that should
-        # produce a prompt; comment/formatting drift must not.
+        # config -> exit 1, and the missing key is printed so the caller can
+        # record only that key on decline (not every non-declined agent). A
+        # missing mirror is the only condition that should produce a prompt;
+        # comment/formatting drift must not.
         name = "check: pending changes detected (mirror missing)"
         try:
             key = "claude_project_dirs"
@@ -330,11 +338,32 @@ def run_self_test() -> None:
             existing_default = default_host_path(key, home)
             cfg = {key: [existing_default]}  # mirror absent
             updated = apply_agents(cfg, [(key, mirror)], home)
-            if updated != cfg:
+            missing = [k for k, _ in [(key, mirror)] if updated.get(k) != cfg.get(k)]
+            if updated != cfg and missing == [key]:
                 ok(name)
             else:
-                fail(name, "apply_agents(config) != config",
-                     "equal (missing mirror not detected)")
+                fail(name, "updated != config and missing == [key]",
+                     f"updated==config? {updated == cfg}; missing={missing}")
+        except Exception:
+            fail(name, traceback.format_exc())
+
+        # Test 10: a malformed config.toml exits 3, not 1, so the shell never
+        # mistakes a parse failure for a pending change (which on a
+        # non-interactive run would be silently swallowed). On Python < 3.11
+        # this also exercises the tomllib shim exposing TOMLDecodeError.
+        name = "malformed config exits 3 (not 1)"
+        try:
+            with open(config_path, "w") as f:
+                f.write("this is = not = valid toml\n")
+            try:
+                read_config(config_path)
+            except SystemExit as e:
+                if e.code == 3:
+                    ok(name)
+                else:
+                    fail(name, "exit 3", f"exit {e.code}")
+            else:
+                fail(name, "SystemExit(3)", "no exit (parse error swallowed)")
         except Exception:
             fail(name, traceback.format_exc())
 
@@ -342,7 +371,7 @@ def run_self_test() -> None:
         for msg in failures:
             print(msg, file=sys.stderr)
         sys.exit(1)
-    print("All 9 self-tests passed.")
+    print("All 10 self-tests passed.")
 
 
 def main() -> None:
@@ -402,6 +431,13 @@ def main() -> None:
     except ConfigError as e:
         print(f"error: {args.config_path}: {e}", file=sys.stderr)
         sys.exit(3)
+    except Exception as e:
+        # Any other failure (PermissionError, OSError, ...) is an error, not
+        # a pending change. read_config already maps a parse failure to exit 3
+        # itself; this catches everything else so the shell can treat exit 1
+        # from --check as "pending" and only "pending".
+        print(f"error: {args.config_path}: {e}", file=sys.stderr)
+        sys.exit(3)
 
     if args.check:
         # Compare parsed values, not rendered text. The writer round-trips
@@ -410,9 +446,14 @@ def main() -> None:
         # which would re-prompt on every run even when every mirror path is
         # already present. Comparing the merged dict to the original is immune
         # to that: exit 0 when the merge is a no-op, 1 when a mirror path is
-        # still missing. (ConfigError is raised inside apply_agents above, so a
-        # scalar managed key exits 3 here before this branch.)
-        sys.exit(0 if updated == config else 1)
+        # still missing. Print the missing keys (one per line) so the caller
+        # can record only those on decline, and 3 on a config error (raised
+        # inside apply_agents above) before this branch.
+        missing = [k for k, _ in agents if updated.get(k) != config.get(k)]
+        if missing:
+            sys.stdout.write("\n".join(missing) + "\n")
+            sys.exit(1)
+        sys.exit(0)
 
     new_content = dumps(updated)
 

--- a/scripts/test-agentsview-resync.sh
+++ b/scripts/test-agentsview-resync.sh
@@ -144,5 +144,45 @@ st=$(status_of /usr/bin/python3 "$PY" --config-path "$CFG" --home "$HOME" --chec
 pass "resync: declined pi is filtered out (no false pending)"
 set +e
 
+###############################################################################
+# Test 6: decline records ONLY the actually-missing key, not every
+# non-declined agent. 4 agents present + pi missing; assert --check reports
+# only pi_dirs, and recording exactly that set leaves the others out. The
+# decline-at-prompt path itself is tty-only (the ! -t 0 guard skips
+# non-interactive), so this tests the logic resync uses on decline: parse
+# --check's missing-key output and record only those.
+###############################################################################
+cat > "$CFG" <<EOF
+claude_project_dirs = ["$HOME/.claude/projects", "$SV_PRIVATE_DIR/sessions/claude"]
+codex_sessions_dirs = ["$HOME/.codex/sessions", "$SV_PRIVATE_DIR/sessions/codex"]
+opencode_dirs = ["$HOME/.local/share/opencode", "$SV_PRIVATE_DIR/sessions/opencode"]
+gemini_dirs = ["$HOME/.gemini", "$SV_PRIVATE_DIR/sessions/gemini"]
+pi_dirs = ["$HOME/.pi/agent/sessions"]
+EOF
+rm -f "$DECLINED"
+missing_out=$(/usr/bin/python3 "$PY" --config-path "$CFG" --home "$HOME" --check \
+    --agent claude_project_dirs="$SV_PRIVATE_DIR/sessions/claude" \
+    --agent codex_sessions_dirs="$SV_PRIVATE_DIR/sessions/codex" \
+    --agent opencode_dirs="$SV_PRIVATE_DIR/sessions/opencode" \
+    --agent gemini_dirs="$SV_PRIVATE_DIR/sessions/gemini" \
+    --agent pi_dirs="$SV_PRIVATE_DIR/sessions/pi" 2>/dev/null || true)
+trimmed=$(printf '%s\n' "$missing_out" | sed '/^$/d')
+[[ "$trimmed" == "pi_dirs" ]] \
+    || fail "--check should report only pi_dirs missing, got: '$trimmed'"
+while IFS= read -r mk; do
+    [[ -n "$mk" ]] && agentsview_record_decline "$mk"
+done <<< "$missing_out"
+count=$(agentsview_declined_keys | grep -c .)
+[[ "$count" -eq 1 ]] || fail "decline list should have 1 key (pi_dirs), got $count"
+agentsview_declined_keys | grep -Fxq -- pi_dirs \
+    || fail "decline list should contain pi_dirs"
+for other in claude_project_dirs codex_sessions_dirs opencode_dirs gemini_dirs; do
+    if agentsview_declined_keys | grep -Fxq -- "$other"; then
+        fail "decline list should NOT contain $other (M1 over-record regression)"
+    fi
+done
+pass "resync: decline records only the missing key (not all agents)"
+set +e
+
 echo
 echo "All integration tests passed."

--- a/scripts/test-agentsview-resync.sh
+++ b/scripts/test-agentsview-resync.sh
@@ -1,0 +1,148 @@
+#!/bin/bash
+# Integration test for the agentsview re-sync + per-key decline flow.
+# Sources the REAL sv-agentsview-setup (functions only) and drives the REAL
+# agentsview-config.py, with HOME/USER pointed at throwaway paths under
+# /Users/Shared so the readonly SV_PRIVATE_DIR resolves somewhere we can
+# create and clean up.
+#
+# The sourced script sets `set -Eeuo pipefail` and an ERR trap, and its
+# functions toggle set -e internally -- which leaks into this shell. So we
+# keep errexit off after sourcing and capture expected-failure statuses with
+# `cmd || st=$?`, which also runs in a conditional context (no abort, ERR
+# trap suppressed).
+# shellcheck disable=SC2154  # SV_PRIVATE_DIR, AGENTSVIEW_*, agentsview_field come from sourcing sv-agentsview-setup + agentsview-paths.sh
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PUB="$SCRIPT_DIR/.."
+
+fail() { echo "FAIL: $1"; exit 1; }
+pass() { echo "PASS: $1"; }
+
+# Unique fake host user so SHARED_WORKSPACE=/Users/Shared/sv-<fake> is ours.
+FAKE_USER="avtest$$"
+export USER="$FAKE_USER"
+TMP_HOME="/tmp/avtest.home.$$"
+mkdir -p "$TMP_HOME/.agentsview"
+export HOME="$TMP_HOME"
+
+cleanup() { rm -rf "/Users/Shared/sv-$FAKE_USER" "$TMP_HOME"; }
+trap cleanup EXIT
+
+# Source with --help so the entry-point case runs print_usage (harmless) and
+# returns, leaving every function defined and the readonly path vars set.
+# shellcheck source=/dev/null
+source "$PUB/sv-agentsview-setup" --help >/dev/null
+set +e   # the sourced script turned errexit on; we drive it ourselves
+
+# Sanity: new function present, old one gone.
+declare -F agentsview_resync_config >/dev/null || fail "agentsview_resync_config not defined"
+if declare -F agentsview_update_config >/dev/null; then fail "old agentsview_update_config still present"; fi
+declare -F agentsview_record_decline >/dev/null || fail "agentsview_record_decline not defined"
+
+CFG="$AGENTSVIEW_HOST_CONFIG"
+DECLINED="$AGENTSVIEW_DECLINED_FILE"
+PY="$PUB/helpers/agentsview-config.py"
+
+mkdir -p "$(dirname "$AGENTSVIEW_STATE_FILE")"
+echo enabled > "$AGENTSVIEW_STATE_FILE"
+
+# Capture a command's exit status without aborting (errexit may be on or off).
+status_of() { local st; "$@" >/dev/null 2>&1 || st=$?; echo "${st:-0}"; }
+
+###############################################################################
+# Test 1: resync with every mirror already present -> no-op (check exits 0)
+###############################################################################
+cat > "$CFG" <<EOF
+claude_project_dirs = ["$HOME/.claude/projects", "$SV_PRIVATE_DIR/sessions/claude"]
+codex_sessions_dirs = ["$HOME/.codex/sessions", "$SV_PRIVATE_DIR/sessions/codex"]
+opencode_dirs = ["$HOME/.local/share/opencode", "$SV_PRIVATE_DIR/sessions/opencode"]
+gemini_dirs = ["$HOME/.gemini", "$SV_PRIVATE_DIR/sessions/gemini"]
+pi_dirs = ["$HOME/.pi/agent/sessions", "$SV_PRIVATE_DIR/sessions/pi"]
+EOF
+agentsview_resync_config </dev/null
+[[ $? -eq 0 ]] || fail "resync (all present) should return 0"
+pass "resync: all mirrors present is a no-op"
+set +e
+
+###############################################################################
+# Test 2: check -> write -> check idempotence (the core of Bug 3).
+###############################################################################
+cat > "$CFG" <<EOF
+claude_project_dirs = ["$HOME/.claude/projects"]
+EOF
+st=$(status_of /usr/bin/python3 "$PY" --config-path "$CFG" --home "$HOME" --check \
+    --agent claude_project_dirs="$SV_PRIVATE_DIR/sessions/claude")
+[[ "$st" -eq 1 ]] || fail "check should exit 1 (pending), got $st"
+/usr/bin/python3 "$PY" --config-path "$CFG" --home "$HOME" --write \
+    --agent claude_project_dirs="$SV_PRIVATE_DIR/sessions/claude" >/dev/null
+st=$(status_of /usr/bin/python3 "$PY" --config-path "$CFG" --home "$HOME" --check \
+    --agent claude_project_dirs="$SV_PRIVATE_DIR/sessions/claude")
+[[ "$st" -eq 0 ]] || fail "after write, check should exit 0, got $st"
+pass "resync: check->write->check is idempotent"
+set +e
+
+###############################################################################
+# Test 3: decline records pending keys permanently (de-duped); resync skips.
+###############################################################################
+cat > "$CFG" <<EOF
+claude_project_dirs = ["$HOME/.claude/projects"]
+pi_dirs = ["$HOME/.pi/agent/sessions"]
+EOF
+rm -f "$DECLINED"
+pending=()
+for agent in "${AGENTSVIEW_AGENTS[@]}"; do
+    pending+=( "$(agentsview_field TOMLKEY "$agent")" )
+done
+agentsview_record_decline "${pending[@]}"
+count=$(agentsview_declined_keys | grep -c .)
+[[ "$count" -eq 5 ]] || fail "declined file should have 5 keys, got $count"
+agentsview_record_decline "${pending[@]}"   # de-dup
+count=$(agentsview_declined_keys | grep -c .)
+[[ "$count" -eq 5 ]] || fail "decline not de-duplicated, got $count"
+agentsview_resync_config </dev/null
+[[ $? -eq 0 ]] || fail "resync (all declined) should return 0"
+pass "resync: all-declined is a no-op (decline de-duped)"
+set +e
+
+###############################################################################
+# Test 4: scalar managed key -> resync errors (return 1), file untouched.
+###############################################################################
+cat > "$CFG" <<'EOF'
+claude_project_dirs = "/some/scalar/path"
+EOF
+rm -f "$DECLINED"
+st=0; agentsview_resync_config </dev/null || st=$?
+[[ "$st" -eq 1 ]] || fail "resync on scalar config should return 1, got $st"
+grep -q '^claude_project_dirs = "/some/scalar/path"$' "$CFG" \
+    || fail "scalar config was rewritten (should be untouched): $(cat "$CFG")"
+pass "resync: scalar config errors cleanly, file untouched"
+set +e
+
+###############################################################################
+# Test 5: partial decline — decline pi only; resync filters it out so check
+# is clean even though pi's mirror is missing.
+###############################################################################
+cat > "$CFG" <<EOF
+claude_project_dirs = ["$HOME/.claude/projects", "$SV_PRIVATE_DIR/sessions/claude"]
+codex_sessions_dirs = ["$HOME/.codex/sessions", "$SV_PRIVATE_DIR/sessions/codex"]
+opencode_dirs = ["$HOME/.local/share/opencode", "$SV_PRIVATE_DIR/sessions/opencode"]
+gemini_dirs = ["$HOME/.gemini", "$SV_PRIVATE_DIR/sessions/gemini"]
+pi_dirs = ["$HOME/.pi/agent/sessions"]
+EOF
+rm -f "$DECLINED"
+agentsview_record_decline pi_dirs
+declined="$(agentsview_declined_keys)"
+agent_args=()
+for agent in "${AGENTSVIEW_AGENTS[@]}"; do
+    tk="$(agentsview_field TOMLKEY "$agent")"
+    printf '%s\n' "$declined" | grep -Fxq -- "$tk" && continue
+    agent_args+=(--agent "$tk=$SV_PRIVATE_DIR/sessions/$agent")
+done
+st=$(status_of /usr/bin/python3 "$PY" --config-path "$CFG" --home "$HOME" --check \
+    "${agent_args[@]}")
+[[ "$st" -eq 0 ]] || fail "with pi declined, check should be 0 (others present), got $st"
+pass "resync: declined pi is filtered out (no false pending)"
+set +e
+
+echo
+echo "All integration tests passed."

--- a/scripts/test-agentsview-resync.sh
+++ b/scripts/test-agentsview-resync.sh
@@ -191,7 +191,16 @@ set +e
 # capture bug treated the expected pending exit 1 as a hard error (return 1),
 # so resync never reached the prompt. Non-interactive is the only way to
 # exercise the post-check path without a tty (interactive prompt needs a
-# real tty); pending -> skip-guard -> return 0 is the observable contract.
+# real tty).
+#
+# exit 0 alone is not enough -- four paths return 0 (all-up-to-date,
+# all-declined, missing-script, non-interactive skip). Distinguish the pending
+# path by setting up a genuinely-missing mirror and asserting the two
+# behaviors the skip guard promises for it: do NOT write the config (the
+# missing mirror is still missing) and do NOT record a decline (no declined
+# file). The all-up-to-date path would have no missing mirror; a bug that
+# writes anyway fails the no-write check; a bug that records anyway fails the
+# no-decline check.
 ###############################################################################
 cat > "$CFG" <<EOF
 claude_project_dirs = ["$HOME/.claude/projects", "$SV_PRIVATE_DIR/sessions/claude"]
@@ -201,10 +210,18 @@ gemini_dirs = ["$HOME/.gemini", "$SV_PRIVATE_DIR/sessions/gemini"]
 pi_dirs = ["$HOME/.pi/agent/sessions"]
 EOF
 rm -f "$DECLINED"
+# Snapshot the config so we can prove it was not rewritten.
+before=$(cat "$CFG")
 st=0; agentsview_resync_config </dev/null || st=$?
 [[ "$st" -eq 0 ]] \
     || fail "pending+non-interactive should skip (exit 0), got exit $st (pending treated as hard error)"
-pass "resync: pending+non-interactive reaches skip guard (exit 0)"
+# Pending path reached: config untouched (no write) ...
+[[ "$(cat "$CFG")" == "$before" ]] \
+    || fail "pending+non-interactive should not write the config"
+# ... and no decline recorded.
+[[ ! -e "$DECLINED" ]] \
+    || fail "pending+non-interactive should not record a decline (file exists)"
+pass "resync: pending+non-interactive reaches skip guard (no write, no decline, exit 0)"
 set +e
 
 echo

--- a/scripts/test-agentsview-resync.sh
+++ b/scripts/test-agentsview-resync.sh
@@ -184,5 +184,28 @@ done
 pass "resync: decline records only the missing key (not all agents)"
 set +e
 
+###############################################################################
+# Test 7: agentsview_resync_config with a missing mirror, non-interactive,
+# reaches the non-interactive skip guard and returns 0 -- NOT the error path.
+# This is the regression codex caught in iter 2: an `if ! cmd` / `if cmd; fi`
+# capture bug treated the expected pending exit 1 as a hard error (return 1),
+# so resync never reached the prompt. Non-interactive is the only way to
+# exercise the post-check path without a tty (interactive prompt needs a
+# real tty); pending -> skip-guard -> return 0 is the observable contract.
+###############################################################################
+cat > "$CFG" <<EOF
+claude_project_dirs = ["$HOME/.claude/projects", "$SV_PRIVATE_DIR/sessions/claude"]
+codex_sessions_dirs = ["$HOME/.codex/sessions", "$SV_PRIVATE_DIR/sessions/codex"]
+opencode_dirs = ["$HOME/.local/share/opencode", "$SV_PRIVATE_DIR/sessions/opencode"]
+gemini_dirs = ["$HOME/.gemini", "$SV_PRIVATE_DIR/sessions/gemini"]
+pi_dirs = ["$HOME/.pi/agent/sessions"]
+EOF
+rm -f "$DECLINED"
+st=0; agentsview_resync_config </dev/null || st=$?
+[[ "$st" -eq 0 ]] \
+    || fail "pending+non-interactive should skip (exit 0), got exit $st (pending treated as hard error)"
+pass "resync: pending+non-interactive reaches skip guard (exit 0)"
+set +e
+
 echo
 echo "All integration tests passed."

--- a/scripts/test-agentsview-resync.sh
+++ b/scripts/test-agentsview-resync.sh
@@ -208,9 +208,9 @@ pi_dirs = ["$HOME/.pi/agent/sessions"]
 EOF
 rm -f "$DECLINED"
 before=$(cat "$CFG")
-log=$(SV_VERBOSE=2 agentsview_resync_config </dev/null 2>&1) || st=$?
-[[ "${st:-0}" -eq 0 ]] \
-    || fail "pending+non-interactive should skip (exit 0), got exit ${st:-0}"
+st=0; log=$(SV_VERBOSE=2 agentsview_resync_config </dev/null 2>&1) || st=$?
+[[ "$st" -eq 0 ]] \
+    || fail "pending+non-interactive should skip (exit 0), got exit $st"
 # The skip guard's trace must name pi_dirs -- proves --check reported it
 # missing AND the pending branch ran (not all-up-to-date, not missing-script).
 [[ "$log" == *"config changes pending"*"pi_dirs"*"non-interactive; skipping"* ]] \
@@ -221,6 +221,37 @@ log=$(SV_VERBOSE=2 agentsview_resync_config </dev/null 2>&1) || st=$?
 [[ ! -e "$DECLINED" ]] \
     || fail "pending+non-interactive should not record a decline (file exists)"
 pass "resync: pending+non-interactive reaches skip guard (observed via trace)"
+set +e
+
+###############################################################################
+# Test 8: --check exit 1 with empty stdout (a protocol violation, e.g. an
+# import-time error in the vendored shim) is a hard error that surfaces the
+# stderr diagnostic -- not silent success, and not a generic message that
+# hides the cause. Uses the AGENTSVIEW_CONFIG_SCRIPT seam to point resync at a
+# stub that exits 1 with empty stdout and a known stderr line.
+###############################################################################
+cat > "$CFG" <<EOF
+claude_project_dirs = ["$HOME/.claude/projects", "$SV_PRIVATE_DIR/sessions/claude"]
+EOF
+rm -f "$DECLINED"
+stub="$TMP_HOME/stub.py"
+cat > "$stub" <<'PY'
+import sys
+sys.stderr.write("boom: import-time traceback marker\n")
+sys.exit(1)  # exit 1, no stdout keys
+PY
+before=$(cat "$CFG")
+st=0; out=$(AGENTSVIEW_CONFIG_SCRIPT="$stub" agentsview_resync_config </dev/null 2>&1) || st=$?
+[[ "$st" -eq 1 ]] \
+    || fail "empty-keys protocol violation should return 1, got $st"
+[[ "$out" == *"reported pending but listed no keys"* ]] \
+    || fail "empty-keys error message missing; got: $out"
+[[ "$out" == *"boom: import-time traceback marker"* ]] \
+    || fail "empty-keys error should surface the stderr diagnostic; got: $out"
+# And it did not silently write or decline.
+[[ "$(cat "$CFG")" == "$before" ]] || fail "empty-keys error should not write"
+[[ ! -e "$DECLINED" ]] || fail "empty-keys error should not record a decline"
+pass "resync: empty-keys protocol violation errors with the stderr diagnostic"
 set +e
 
 echo

--- a/scripts/test-agentsview-resync.sh
+++ b/scripts/test-agentsview-resync.sh
@@ -186,21 +186,18 @@ set +e
 
 ###############################################################################
 # Test 7: agentsview_resync_config with a missing mirror, non-interactive,
-# reaches the non-interactive skip guard and returns 0 -- NOT the error path.
-# This is the regression codex caught in iter 2: an `if ! cmd` / `if cmd; fi`
-# capture bug treated the expected pending exit 1 as a hard error (return 1),
-# so resync never reached the prompt. Non-interactive is the only way to
-# exercise the post-check path without a tty (interactive prompt needs a
-# real tty).
+# reaches the non-interactive skip guard -- NOT some other exit-0 path.
+# This is the regression codex caught in iter 2 (capture bug returned 1) and
+# the one codex+claude-code re-raised in iter 3: "exit 0 + no-write +
+# no-decline" is true for every exit-0 path (all-up-to-date, all-declined,
+# missing-script, skip-guard), so it doesn't prove the pending branch ran.
 #
-# exit 0 alone is not enough -- four paths return 0 (all-up-to-date,
-# all-declined, missing-script, non-interactive skip). Distinguish the pending
-# path by setting up a genuinely-missing mirror and asserting the two
-# behaviors the skip guard promises for it: do NOT write the config (the
-# missing mirror is still missing) and do NOT record a decline (no declined
-# file). The all-up-to-date path would have no missing mirror; a bug that
-# writes anyway fails the no-write check; a bug that records anyway fails the
-# no-decline check.
+# Observe the branch directly: run with SV_VERBOSE=2 (enables `trace`) and
+# capture stderr, then assert the skip guard's trace message names the
+# missing key. Only the pending-skip path emits "config changes pending ... 
+# non-interactive; skipping" with the key in it. A bug where --check reports
+# clean (no keys) reaches a different branch; a missing script returns early
+# with a different trace; the all-up-to-date path has no missing mirror.
 ###############################################################################
 cat > "$CFG" <<EOF
 claude_project_dirs = ["$HOME/.claude/projects", "$SV_PRIVATE_DIR/sessions/claude"]
@@ -210,18 +207,20 @@ gemini_dirs = ["$HOME/.gemini", "$SV_PRIVATE_DIR/sessions/gemini"]
 pi_dirs = ["$HOME/.pi/agent/sessions"]
 EOF
 rm -f "$DECLINED"
-# Snapshot the config so we can prove it was not rewritten.
 before=$(cat "$CFG")
-st=0; agentsview_resync_config </dev/null || st=$?
-[[ "$st" -eq 0 ]] \
-    || fail "pending+non-interactive should skip (exit 0), got exit $st (pending treated as hard error)"
-# Pending path reached: config untouched (no write) ...
+log=$(SV_VERBOSE=2 agentsview_resync_config </dev/null 2>&1) || st=$?
+[[ "${st:-0}" -eq 0 ]] \
+    || fail "pending+non-interactive should skip (exit 0), got exit ${st:-0}"
+# The skip guard's trace must name pi_dirs -- proves --check reported it
+# missing AND the pending branch ran (not all-up-to-date, not missing-script).
+[[ "$log" == *"config changes pending"*"pi_dirs"*"non-interactive; skipping"* ]] \
+    || fail "pending-skip trace not found; got: $log"
+# ... and it did not write or decline.
 [[ "$(cat "$CFG")" == "$before" ]] \
     || fail "pending+non-interactive should not write the config"
-# ... and no decline recorded.
 [[ ! -e "$DECLINED" ]] \
     || fail "pending+non-interactive should not record a decline (file exists)"
-pass "resync: pending+non-interactive reaches skip guard (no write, no decline, exit 0)"
+pass "resync: pending+non-interactive reaches skip guard (observed via trace)"
 set +e
 
 echo

--- a/scripts/test-agentsview-resync.sh
+++ b/scripts/test-agentsview-resync.sh
@@ -282,5 +282,28 @@ err_lines=$(printf '%s\n' "$out" | grep -c '❌')
 pass "resync: empty-keys with no stderr errors without a bare diagnostic line"
 set +e
 
+###############################################################################
+# Test 10: the AGENTSVIEW_CONFIG_SCRIPT seam — when the override points at a
+# nonexistent path, resync skips (return 0) and the skip trace names the
+# *overridden* path, not the installed default (which exists in this tree, so
+# the old hardcoded message would name a present, irrelevant file).
+###############################################################################
+cat > "$CFG" <<EOF
+claude_project_dirs = ["$HOME/.claude/projects", "$SV_PRIVATE_DIR/sessions/claude"]
+EOF
+rm -f "$DECLINED"
+fake="$TMP_HOME/does-not-exist.py"
+st=0; log=$(SV_VERBOSE=2 AGENTSVIEW_CONFIG_SCRIPT="$fake" agentsview_resync_config </dev/null 2>&1) || st=$?
+[[ "$st" -eq 0 ]] \
+    || fail "missing override script should skip (exit 0), got $st"
+[[ "$log" == *"$fake not installed; skipping config resync"* ]] \
+    || fail "skip trace should name the overridden path '$fake'; got: $log"
+# And it must NOT name the default path (which exists here) -- the bug was that
+# it silently named a present, irrelevant file.
+[[ "$log" != *"helpers/agentsview-config.py not installed"* ]] \
+    || fail "skip trace should not name the default path; got: $log"
+pass "resync: not-installed trace names the overridden script path"
+set +e
+
 echo
 echo "All integration tests passed."

--- a/scripts/test-agentsview-resync.sh
+++ b/scripts/test-agentsview-resync.sh
@@ -241,7 +241,7 @@ sys.stderr.write("boom: import-time traceback marker\n")
 sys.exit(1)  # exit 1, no stdout keys
 PY
 before=$(cat "$CFG")
-st=0; out=$(AGENTSVIEW_CONFIG_SCRIPT="$stub" agentsview_resync_config </dev/null 2>&1) || st=$?
+st=0; out=$( trap - ERR; AGENTSVIEW_CONFIG_SCRIPT="$stub" agentsview_resync_config </dev/null 2>&1 ) || st=$?
 [[ "$st" -eq 1 ]] \
     || fail "empty-keys protocol violation should return 1, got $st"
 [[ "$out" == *"reported pending but listed no keys"* ]] \
@@ -252,6 +252,34 @@ st=0; out=$(AGENTSVIEW_CONFIG_SCRIPT="$stub" agentsview_resync_config </dev/null
 [[ "$(cat "$CFG")" == "$before" ]] || fail "empty-keys error should not write"
 [[ ! -e "$DECLINED" ]] || fail "empty-keys error should not record a decline"
 pass "resync: empty-keys protocol violation errors with the stderr diagnostic"
+set +e
+
+###############################################################################
+# Test 9: the empty-keys error when --check violates protocol with NO stderr
+# (a bare sys.exit(1), empty stdout, empty stderr). Must still error (return
+# 1) but must NOT emit a bare noisy diagnostic line -- only the message.
+###############################################################################
+cat > "$CFG" <<EOF
+claude_project_dirs = ["$HOME/.claude/projects", "$SV_PRIVATE_DIR/sessions/claude"]
+EOF
+rm -f "$DECLINED"
+stub2="$TMP_HOME/stub2.py"
+cat > "$stub2" <<'PY'
+import sys
+sys.exit(1)  # exit 1, no stdout, no stderr
+PY
+before=$(cat "$CFG")
+st=0; out=$( trap - ERR; AGENTSVIEW_CONFIG_SCRIPT="$stub2" agentsview_resync_config </dev/null 2>&1 ) || st=$?
+[[ "$st" -eq 1 ]] \
+    || fail "empty-keys (no stderr) should return 1, got $st"
+[[ "$out" == *"reported pending but listed no keys"* ]] \
+    || fail "empty-keys error message missing; got: $out"
+# No bare diagnostic line: the only error line is the message itself.
+err_lines=$(printf '%s\n' "$out" | grep -c '❌')
+[[ "$err_lines" -eq 1 ]] \
+    || fail "empty-keys (no stderr) should emit exactly one error line, got $err_lines: $out"
+[[ "$(cat "$CFG")" == "$before" ]] || fail "empty-keys error should not write"
+pass "resync: empty-keys with no stderr errors without a bare diagnostic line"
 set +e
 
 echo

--- a/scripts/tests
+++ b/scripts/tests
@@ -1854,6 +1854,89 @@ print(mod["DEFAULT_SUBPATHS"].get(sys.argv[2], "<missing>"))
     }
     queue_test test_agentsview_default_tables_agree
 
+    # The config writer's --check mode compares parsed values, not rendered
+    # text, so a hand-edited config.toml (comments, formatting drift) doesn't
+    # produce a perpetual non-empty diff that would re-prompt on every run.
+    # Exit 0 = clean, 1 = a mirror path is missing, 3 = config error (e.g. a
+    # scalar where an array belongs, which list() would char-split).
+    test_agentsview_config_check_mode() {
+        local tmpdir cfg home st out
+        tmpdir=$(mktemp -d)
+        cfg="$tmpdir/config.toml"
+        home="$tmpdir/home"
+        mkdir -p "$home/.claude/projects"
+        local mirror="$tmpdir/sessions/claude"
+        local default="$home/.claude/projects"
+        local results=""
+
+        # clean: mirror already present -> 0
+        printf 'claude_project_dirs = ["%s", "%s"]\n' "$default" "$mirror" > "$cfg"
+        set +e; /usr/bin/python3 "$AGENTSVIEW_CONFIG_SCRIPT" \
+            --config-path "$cfg" --home "$home" --check \
+            --agent claude_project_dirs="$mirror" >/dev/null 2>&1; st=$?; set -e
+        [[ "$st" -eq 0 ]] || results+="clean:$st "
+
+        # pending: mirror missing -> 1
+        printf 'claude_project_dirs = ["%s"]\n' "$default" > "$cfg"
+        set +e; /usr/bin/python3 "$AGENTSVIEW_CONFIG_SCRIPT" \
+            --config-path "$cfg" --home "$home" --check \
+            --agent claude_project_dirs="$mirror" >/dev/null 2>&1; st=$?; set -e
+        [[ "$st" -eq 1 ]] || results+="pending:$st "
+
+        # error: scalar value -> 3 (not char-split on write)
+        printf 'claude_project_dirs = "/some/scalar/path"\n' > "$cfg"
+        set +e; out=$(/usr/bin/python3 "$AGENTSVIEW_CONFIG_SCRIPT" \
+            --config-path "$cfg" --home "$home" --check \
+            --agent claude_project_dirs="$mirror" 2>&1); st=$?; set -e
+        [[ "$st" -eq 3 ]] || results+="scalar:$st "
+        # Clean error message, not a silent char-split.
+        [[ "$out" == *"must be an array of paths"* ]] || results+="scalar-msg "
+        # And the scalar file must be left untouched (no char-split rewrite).
+        grep -q '^claude_project_dirs = "/some/scalar/path"$' "$cfg" \
+            || results+="scalar-rewritten "
+
+        rm -rf "$tmpdir"
+        if [[ -z "$results" ]]; then
+            pass "agentsview-config.py --check exits 0/1/3 correctly"
+        else
+            fail "agentsview-config.py --check exits 0/1/3 correctly" \
+                "clean=0 pending=1 scalar=3 untouched" "$results"
+        fi
+    }
+    queue_test test_agentsview_config_check_mode
+
+    # Structural: sv-agentsview-setup re-syncs on every run (not prompt-once),
+    # and the per-key decline list is the permanent-skip mechanism. Assert the
+    # new wiring is present and the old prompt-once flow is gone, the way the
+    # other setup-merge structural tests do.
+    test_agentsview_resync_wiring() {
+        local setup="$SCRIPT_DIR/../sv-agentsview-setup"
+        if [[ ! -r "$setup" ]]; then
+            fail "agentsview resync wiring" "readable sv-agentsview-setup" "$setup"
+            return
+        fi
+        local missing=""
+        grep -Fq -- 'agentsview_resync_config()' "$setup" || missing+="resync-fn "
+        grep -Fq -- 'agentsview_first_run_prompt()' "$setup" || missing+="first-run-fn "
+        grep -Fq -- 'agentsview_record_decline()' "$setup" || missing+="record-decline-fn "
+        grep -Fq -- 'AGENTSVIEW_DECLINED_FILE' "$setup" || missing+="declined-var "
+        grep -Fq -- '--check' "$setup" || missing+="check-arg "
+        # old prompt-once flow must be gone
+        if grep -Fq -- 'agentsview_update_config()' "$setup"; then
+            missing+="old-update-fn-present "
+        fi
+        # re-sync must run when enabled (not only at opt-in)
+        grep -Fq -- 'agentsview_install_symlinks' "$setup" || missing+="install-symlinks "
+        if [[ -z "$missing" ]]; then
+            pass "agentsview resync wiring present, prompt-once gone"
+        else
+            fail "agentsview resync wiring present, prompt-once gone" \
+                "resync fn + first-run + decline + --check, no old update" \
+                "$missing"
+        fi
+    }
+    queue_test test_agentsview_resync_wiring
+
     ###############################################################################
     # Summary
     ###############################################################################

--- a/scripts/tests
+++ b/scripts/tests
@@ -1895,12 +1895,20 @@ print(mod["DEFAULT_SUBPATHS"].get(sys.argv[2], "<missing>"))
         grep -q '^claude_project_dirs = "/some/scalar/path"$' "$cfg" \
             || results+="scalar-rewritten "
 
+        # error: malformed TOML -> 3, not 1 (so a non-interactive run never
+        # mistakes a parse failure for a pending change and swallows it).
+        printf 'bad = = = invalid toml\n' > "$cfg"
+        set +e; /usr/bin/python3 "$AGENTSVIEW_CONFIG_SCRIPT" \
+            --config-path "$cfg" --home "$home" --check \
+            --agent claude_project_dirs="$mirror" >/dev/null 2>&1; st=$?; set -e
+        [[ "$st" -eq 3 ]] || results+="malformed:$st "
+
         rm -rf "$tmpdir"
         if [[ -z "$results" ]]; then
             pass "agentsview-config.py --check exits 0/1/3 correctly"
         else
             fail "agentsview-config.py --check exits 0/1/3 correctly" \
-                "clean=0 pending=1 scalar=3 untouched" "$results"
+                "clean=0 pending=1 scalar=3 malformed=3 untouched" "$results"
         fi
     }
     queue_test test_agentsview_config_check_mode
@@ -1936,6 +1944,32 @@ print(mod["DEFAULT_SUBPATHS"].get(sys.argv[2], "<missing>"))
         fi
     }
     queue_test test_agentsview_resync_wiring
+
+    # The standalone integration test sources the real sv-agentsview-setup
+    # functions and drives the real python writer through the re-sync +
+    # decline flow end to end (no-op, check->write->check idempotence, decline
+    # de-dup + skip, scalar clean error, partial-decline filter). It isolates
+    # itself with a throwaway USER/HOME under /Users/Shared and cleans up, so it
+    # is safe to run from inside the suite. Wire it in so the real resync path
+    # is covered in CI, not just the structural greps above.
+    test_agentsview_resync_integration() {
+        local t="$SCRIPT_DIR/test-agentsview-resync.sh"
+        if [[ ! -x "$t" ]]; then
+            fail "agentsview resync integration" "executable $t" "$t"
+            return
+        fi
+        local out status
+        set +e
+        out=$("$t" 2>&1)
+        status=$?
+        set -e
+        if [[ "$status" -eq 0 ]]; then
+            pass "agentsview resync integration"
+        else
+            fail "agentsview resync integration" "exit 0" "exit $status: $out"
+        fi
+    }
+    queue_test test_agentsview_resync_integration
 
     ###############################################################################
     # Summary

--- a/sv-agentsview-setup
+++ b/sv-agentsview-setup
@@ -156,7 +156,12 @@ agentsview_record_decline() {
 # doesn't re-prompt forever. On decline, records the pending keys permanently
 # so the next run skips them. Returns 0 on success/no-op, 1 on failure.
 agentsview_resync_config() {
-    local script="$WORKSPACE/helpers/agentsview-config.py"
+    # $AGENTSVIEW_CONFIG_SCRIPT overrides the helper path (defaults to the
+    # installed script). The override is a test seam -- it lets the integration
+    # suite point resync at a stub to exercise error paths the real writer
+    # cannot produce -- and is safe because this is an unprivileged,
+    # user-invoked setup script.
+    local script="${AGENTSVIEW_CONFIG_SCRIPT:-$WORKSPACE/helpers/agentsview-config.py}"
     if [[ ! -f "$script" ]]; then
         trace "agentsview: helpers/agentsview-config.py not installed; skipping config resync"
         return 0
@@ -196,7 +201,7 @@ agentsview_resync_config() {
     # set -E propagates it into the subshell where it fires independently of
     # the outer conditional context.
     local check_out check_err check_status missing_keys=()
-    check_err=$(mktemp) || { error "agentsview: cannot create temp file for config check"; return 1; }
+    check_err=$( trap - ERR; mktemp ) || { error "agentsview: cannot create temp file for config check"; return 1; }
     check_out="$( trap - ERR; /usr/bin/python3 "$script" \
         --config-path "$AGENTSVIEW_HOST_CONFIG" \
         --home "$HOME" \
@@ -205,6 +210,9 @@ agentsview_resync_config() {
     # exit 0 = nothing missing; exit 1 = pending (stdout lists the missing
     # keys); anything else (3 = config error, or an uncaught failure now
     # mapped to 3 inside the script) is a hard error, not a pending change.
+    # check_err is freed only once we no longer need the stderr text: the
+    # pending branch may still need it for the empty-keys protocol-violation
+    # error below, so it is NOT rm'd in the case 1) arm.
     case "$check_status" in
         0)
             rm -f "$check_err"
@@ -212,8 +220,8 @@ agentsview_resync_config() {
             return 0
             ;;
         1)
-            rm -f "$check_err"
-            ;;  # pending -- fall through
+            ;;  # pending -- fall through (check_err kept for the empty-keys
+              #      error if --check produced no keys)
         *)
             error "agentsview: cannot update $AGENTSVIEW_HOST_CONFIG:"
             error "$(cat "$check_err" 2>/dev/null)"
@@ -233,13 +241,15 @@ agentsview_resync_config() {
     if [[ ${#missing_keys[@]} -eq 0 ]]; then
         # We only reach here on check_status==1 (the 0 case returned above). An
         # exit 1 with no keys is a protocol violation -- e.g. an import-time
-        # error in the vendored tomli shim exiting 1 with empty stdout -- not a
-        # clean config. Don't silently treat it as up to date (the message
-        # would be byte-identical to the genuine clean case and hide the
-        # failure).
+        # error in the vendored tomli shim exiting 1 with empty stdout and a
+        # traceback on stderr -- not a clean config. Surface the stderr so the
+        # user can diagnose it; do not silently treat it as up to date.
         error "agentsview: --check reported pending but listed no keys; cannot update $AGENTSVIEW_HOST_CONFIG"
+        error "$(cat "$check_err" 2>/dev/null)"
+        rm -f "$check_err"
         return 1
     fi
+    rm -f "$check_err"
 
     # Build --agent args for only the missing keys, so the diff and write are
     # scoped to what's actually changing.
@@ -264,7 +274,7 @@ agentsview_resync_config() {
     # stderr (errors) separately so a stderr line is never rendered as if it
     # were part of the proposed config diff above the prompt.
     local diff_out diff_err
-    diff_err=$(mktemp) || { error "agentsview: cannot create temp file for config diff"; return 1; }
+    diff_err=$( trap - ERR; mktemp ) || { error "agentsview: cannot create temp file for config diff"; return 1; }
     if ! diff_out="$( trap - ERR; /usr/bin/python3 "$script" \
         --config-path "$AGENTSVIEW_HOST_CONFIG" \
         --home "$HOME" \

--- a/sv-agentsview-setup
+++ b/sv-agentsview-setup
@@ -46,6 +46,11 @@ readonly SHARED_WORKSPACE="/Users/Shared/sv-$HOST_USER"
 readonly SV_PRIVATE_DIR="$SHARED_WORKSPACE/_sandvault"
 readonly AGENTSVIEW_STATE_FILE="$SV_PRIVATE_DIR/setup/agentsview-export.state"
 readonly AGENTSVIEW_HOST_CONFIG="$HOME/.agentsview/config.toml"
+# Per-key permanent decline list (one agentsview TOML key per line). An agent
+# whose key is listed here is never re-prompted for a config scan path; the
+# symlink and ACL are still installed, since they're harmless without the scan
+# path. Remove the line to re-enable an agent. Written on first decline.
+readonly AGENTSVIEW_DECLINED_FILE="$SV_PRIVATE_DIR/setup/agentsview-declined.keys"
 
 ###############################################################################
 # Detection / pre-flight
@@ -111,17 +116,94 @@ agentsview_install_symlinks() {
     done
 }
 
-# Update the host user's agentsview config.toml. Shows a diff and prompts.
-# Returns 0 on success (or no-op), 1 on failure.
-agentsview_update_config() {
+# Print permanently-declined TOML keys, one per line (blank/comment lines
+# stripped). Empty output if the file is missing.
+agentsview_declined_keys() {
+    [[ -f "$AGENTSVIEW_DECLINED_FILE" ]] || return 0
+    grep -v '^[[:space:]]*$' "$AGENTSVIEW_DECLINED_FILE" 2>/dev/null \
+        | grep -v '^[[:space:]]*#' 2>/dev/null || true
+}
+
+# Record TOML keys (args) as permanently declined, de-duplicated against the
+# existing list. Idempotent.
+agentsview_record_decline() {
+    mkdir -p "$SV_PRIVATE_DIR/setup"
+    local existing key
+    existing="$(agentsview_declined_keys)"
+    for key in "$@"; do
+        [[ -n "$key" ]] || continue
+        if printf '%s\n' "$existing" | grep -Fxq -- "$key"; then
+            continue
+        fi
+        printf '%s\n' "$key" >> "$AGENTSVIEW_DECLINED_FILE"
+    done
+}
+
+# Re-sync the host agentsview config: for every managed agent the user has
+# not permanently declined, add the mirror scan path if it's missing. Prompts
+# only when a mirror path is actually absent -- compared on parsed values,
+# not rendered text, so comment/formatting drift on a hand-edited config.toml
+# doesn't re-prompt forever. On decline, records the pending keys permanently
+# so the next run skips them. Returns 0 on success/no-op, 1 on failure.
+agentsview_resync_config() {
     local script="$WORKSPACE/helpers/agentsview-config.py"
+    if [[ ! -f "$script" ]]; then
+        trace "agentsview: helpers/agentsview-config.py not installed; skipping config resync"
+        return 0
+    fi
+
+    # Filter out permanently-declined agents.
+    local declined agent tomlkey link
+    declined="$(agentsview_declined_keys)"
     local agent_args=()
-    local agent tomlkey link
+    local pending_keys=()
     for agent in "${AGENTSVIEW_AGENTS[@]}"; do
         tomlkey="$(agentsview_field TOMLKEY "$agent")"
+        if printf '%s\n' "$declined" | grep -Fxq -- "$tomlkey"; then
+            trace "agentsview: $agent ($tomlkey) permanently declined; skipping"
+            continue
+        fi
         link="$SV_PRIVATE_DIR/sessions/$agent"
         agent_args+=(--agent "$tomlkey=$link")
+        pending_keys+=("$tomlkey")
     done
+
+    if [[ ${#pending_keys[@]} -eq 0 ]]; then
+        debug "agentsview: every agent declined; nothing to resync"
+        return 0
+    fi
+
+    # --check compares parsed values: 0 = clean, 1 = a mirror path is missing,
+    # 3 = config error (e.g. a scalar where an array belongs).
+    local check_out check_status
+    set +e
+    check_out="$(/usr/bin/python3 "$script" \
+        --config-path "$AGENTSVIEW_HOST_CONFIG" \
+        --home "$HOME" \
+        --check \
+        "${agent_args[@]}" 2>&1)"
+    check_status=$?
+    set -e
+    if [[ "$check_status" -eq 3 ]]; then
+        error "agentsview: cannot update $AGENTSVIEW_HOST_CONFIG:"
+        error "$check_out"
+        return 1
+    fi
+    if [[ "$check_status" -ne 1 ]]; then
+        if [[ "$check_status" -ne 0 ]]; then
+            error "agentsview: --check failed (exit $check_status): $check_out"
+            return 1
+        fi
+        debug "agentsview: $AGENTSVIEW_HOST_CONFIG already up to date"
+        return 0
+    fi
+
+    # Pending changes. Non-interactive: don't write, don't hang on read, and
+    # don't record a decline (the user never saw the prompt).
+    if [[ ! -t 0 ]]; then
+        trace "agentsview: config changes pending but non-interactive; skipping"
+        return 0
+    fi
 
     local diff_out
     if ! diff_out="$(/usr/bin/python3 "$script" \
@@ -134,22 +216,21 @@ agentsview_update_config() {
         return 1
     fi
 
-    if [[ -z "$diff_out" ]]; then
-        debug "agentsview: $AGENTSVIEW_HOST_CONFIG already up to date"
-        return 0
-    fi
-
     info ""
-    info "Proposed changes to $AGENTSVIEW_HOST_CONFIG:"
+    info "Sandvault added new agents since you last synced. Proposed changes to"
+    info "$AGENTSVIEW_HOST_CONFIG:"
     info ""
     printf '%s\n' "$diff_out"
     info ""
     info "Note: writing this file does not preserve comments on managed keys."
+    info "Decline now to skip these agents permanently (remove the key from"
+    info "$AGENTSVIEW_DECLINED_FILE to re-enable)."
     printf 'Apply these changes? [y/N] '
     local reply
     read -r reply
     if [[ "$reply" != "y" && "$reply" != "Y" ]]; then
-        info "agentsview: skipped config update"
+        info "agentsview: declined; recording ${pending_keys[*]} as permanently skipped"
+        agentsview_record_decline "${pending_keys[@]}"
         return 0
     fi
 
@@ -174,8 +255,9 @@ write_setup_merge_script() {
     # Build the subdir list from AGENTSVIEW_AGENTS (the single source of truth
     # in helpers/agentsview-paths.sh) so this generated script picks up new
     # agents automatically instead of drifting like a hardcoded list would.
-    # Only this generated script tracks the list; the host-side symlink and
-    # TOML key are still written once, at opt-in.
+    # The host-side symlink and TOML scan path are re-synced on every run by
+    # agentsview_resync_config / agentsview_install_symlinks, so a new agent
+    # is wired end to end the first time it has a session.
     local agent _q _subdir _private subdir_list="" private_list=""
     for agent in "${AGENTSVIEW_AGENTS[@]}"; do
         _subdir="$(agentsview_field SUBDIR "$agent")"
@@ -236,40 +318,17 @@ SETUP_EOF
     chmod +x "$SV_PRIVATE_DIR/setup/agentsview-export"
 }
 
-# Orchestrate the full opt-in flow. Idempotent: skips silently if state
-# file already records a choice.
-agentsview_setup() {
-    # Always write the setup-merge script (it's a no-op until opt-in records
-    # `enabled`). This way, opt-in via `sv-agentsview-setup` after the
-    # initial `sv setup --rebuild` still wires up the sandbox-side ACL hook.
-    write_setup_merge_script
-
-    if [[ -f "$AGENTSVIEW_STATE_FILE" ]]; then
-        trace "agentsview: choice already recorded ($(cat "$AGENTSVIEW_STATE_FILE")); skipping prompt"
-        # A user who opted in before sandvault knew about an agent has no mirror
-        # symlink for it, and no scan path in config.toml. The generated ACL
-        # script tracks AGENTSVIEW_AGENTS, but these two steps run once, at
-        # opt-in. Report the gap: silence here looks identical to success.
-        if [[ "$(cat "$AGENTSVIEW_STATE_FILE")" == "enabled" ]]; then
-            local agent missing=""
-            for agent in "${AGENTSVIEW_AGENTS[@]}"; do
-                [[ -e "$SV_PRIVATE_DIR/sessions/$agent" ]] || missing+="$agent "
-            done
-            if [[ -n "$missing" ]]; then
-                info "agentsview: these agents have no mirror: ${missing% }"
-                info "agentsview: to add them, delete $AGENTSVIEW_STATE_FILE."
-                info "agentsview: then run \`sv-agentsview-setup\` again."
-            fi
-        fi
-        return 0
-    fi
+# First-run opt-in prompt. Shown only when no choice is recorded yet. Returns 0
+# to continue (opted in), 1 to stop (declined / not detected / non-interactive).
+# Persists `enabled`/`disabled` to the state file.
+agentsview_first_run_prompt() {
     if [[ ! -t 0 ]]; then
         trace "agentsview: non-interactive; skipping prompt"
-        return 0
+        return 1
     fi
     if [[ ! -f "$WORKSPACE/helpers/agentsview-config.py" ]]; then
         trace "agentsview: helpers/agentsview-config.py not installed; skipping"
-        return 0
+        return 1
     fi
     # SC2310: these functions are designed to return a status (detection /
     # pre-flight check). Their bodies don't rely on set -e, so the disabled
@@ -277,13 +336,13 @@ agentsview_setup() {
     # shellcheck disable=SC2310
     if ! agentsview_detect; then
         trace "agentsview: not detected; skipping"
-        return 0
+        return 1
     fi
     # shellcheck disable=SC2310
     if ! agentsview_contamination_check; then
         # Pre-flight already printed remediation. Don't persist a choice;
         # user re-runs after fixing.
-        return 0
+        return 1
     fi
 
     info ""
@@ -296,9 +355,8 @@ agentsview_setup() {
     info "  - add a scan path per agent to $AGENTSVIEW_HOST_CONFIG (with diff confirmation)"
     info "  - rewrite your agentsview config without preserving comments"
     info ""
-    info "Sandvault does not track new agents automatically. This applies to agents"
-    info "that agentsview adds, and to agents that sandvault adds in a later version."
-    info "To refresh, delete $AGENTSVIEW_STATE_FILE and run this command again."
+    info "New agents sandvault adds later are synced automatically on the next run."
+    info "Decline a sync prompt to skip that agent permanently."
     printf 'Enable agentsview export? [y/N] '
     local reply
     read -r reply
@@ -306,12 +364,39 @@ agentsview_setup() {
     if [[ "$reply" != "y" && "$reply" != "Y" ]]; then
         echo disabled > "$AGENTSVIEW_STATE_FILE"
         info "agentsview: export disabled"
-        return 0
+        return 1
     fi
 
     echo enabled > "$AGENTSVIEW_STATE_FILE"
+    return 0
+}
+
+# Orchestrate the agentsview export. Prompts once on first run, then re-syncs
+# on every invocation once enabled -- so agents added after opt-in get their
+# mirror symlink and scan path without re-running the whole opt-in. Returns 0
+# on success/no-op, non-zero on failure (errors already printed).
+agentsview_setup() {
+    # Always write the setup-merge script (it's a no-op until opt-in records
+    # `enabled`). This way, opt-in via `sv-agentsview-setup` after the
+    # initial `sv setup --rebuild` still wires up the sandbox-side ACL hook,
+    # and new agents land in the generated ACL loop automatically.
+    write_setup_merge_script
+
+    # First-run opt-in: prompt only when no choice is recorded yet.
+    if [[ ! -f "$AGENTSVIEW_STATE_FILE" ]]; then
+        agentsview_first_run_prompt || return 0
+    fi
+
+    # Re-sync runs on every invocation once enabled. This closes the gap for
+    # agents added after opt-in: the symlink and the config scan path used to
+    # be written once, at opt-in, so a new agent stayed invisible until the
+    # user deleted the state file and re-ran the whole prompt. Now the symlink
+    # is refreshed every run, and the scan path is added (with a prompt) the
+    # first time it's missing.
+    [[ "$(cat "$AGENTSVIEW_STATE_FILE")" == "enabled" ]] || return 0
+
     agentsview_install_symlinks
-    agentsview_update_config
+    agentsview_resync_config
 }
 
 ###############################################################################
@@ -322,14 +407,20 @@ print_usage() {
     cat <<EOF
 Usage: sv-agentsview-setup [--help]
 
-Detect agentsview, prompt once on first run, install mirror symlinks,
-update host config.toml, and write the sandbox-side setup-merge script.
+Detect agentsview, prompt once on first run, then re-sync on every run:
+install mirror symlinks, add missing scan paths to host config.toml, and
+write the sandbox-side setup-merge script.
+
+New agents sandvault adds after opt-in are synced automatically. Decline a
+sync prompt to skip that agent permanently; remove its key from the
+declined-keys file to re-enable it.
 
 Uninstall is handled by \`sv uninstall\`, which removes $SV_PRIVATE_DIR/.
 Host config.toml is left in place (revert is a one-line manual edit).
 
-State file: $AGENTSVIEW_STATE_FILE
-Host config: $AGENTSVIEW_HOST_CONFIG
+State file:       $AGENTSVIEW_STATE_FILE
+Declined keys:    $AGENTSVIEW_DECLINED_FILE
+Host config:      $AGENTSVIEW_HOST_CONFIG
 EOF
 }
 

--- a/sv-agentsview-setup
+++ b/sv-agentsview-setup
@@ -196,7 +196,7 @@ agentsview_resync_config() {
     # set -E propagates it into the subshell where it fires independently of
     # the outer conditional context.
     local check_out check_err check_status missing_keys=()
-    check_err=$(mktemp)
+    check_err=$(mktemp) || { error "agentsview: cannot create temp file for config check"; return 1; }
     check_out="$( trap - ERR; /usr/bin/python3 "$script" \
         --config-path "$AGENTSVIEW_HOST_CONFIG" \
         --home "$HOME" \
@@ -231,8 +231,14 @@ agentsview_resync_config() {
         [[ -n "$key" ]] && missing_keys+=("$key")
     done <<< "$check_out"
     if [[ ${#missing_keys[@]} -eq 0 ]]; then
-        debug "agentsview: $AGENTSVIEW_HOST_CONFIG already up to date"
-        return 0
+        # We only reach here on check_status==1 (the 0 case returned above). An
+        # exit 1 with no keys is a protocol violation -- e.g. an import-time
+        # error in the vendored tomli shim exiting 1 with empty stdout -- not a
+        # clean config. Don't silently treat it as up to date (the message
+        # would be byte-identical to the genuine clean case and hide the
+        # failure).
+        error "agentsview: --check reported pending but listed no keys; cannot update $AGENTSVIEW_HOST_CONFIG"
+        return 1
     fi
 
     # Build --agent args for only the missing keys, so the diff and write are
@@ -254,16 +260,22 @@ agentsview_resync_config() {
         return 0
     fi
 
-    local diff_out
+    # Show the diff for only the missing keys. Capture stdout (the diff) and
+    # stderr (errors) separately so a stderr line is never rendered as if it
+    # were part of the proposed config diff above the prompt.
+    local diff_out diff_err
+    diff_err=$(mktemp) || { error "agentsview: cannot create temp file for config diff"; return 1; }
     if ! diff_out="$( trap - ERR; /usr/bin/python3 "$script" \
         --config-path "$AGENTSVIEW_HOST_CONFIG" \
         --home "$HOME" \
         --diff \
-        "${missing_args[@]}" 2>&1)"; then
+        "${missing_args[@]}" 2>"$diff_err" )"; then
         error "agentsview: failed to compute config diff:"
-        error "$diff_out"
+        error "$(cat "$diff_err" 2>/dev/null)"
+        rm -f "$diff_err"
         return 1
     fi
+    rm -f "$diff_err"
 
     info ""
     info "Sandvault added new agents since you last synced. Proposed changes to"

--- a/sv-agentsview-setup
+++ b/sv-agentsview-setup
@@ -156,7 +156,6 @@ agentsview_resync_config() {
     local declined agent tomlkey link
     declined="$(agentsview_declined_keys)"
     local agent_args=()
-    local pending_keys=()
     for agent in "${AGENTSVIEW_AGENTS[@]}"; do
         tomlkey="$(agentsview_field TOMLKEY "$agent")"
         if printf '%s\n' "$declined" | grep -Fxq -- "$tomlkey"; then
@@ -165,43 +164,67 @@ agentsview_resync_config() {
         fi
         link="$SV_PRIVATE_DIR/sessions/$agent"
         agent_args+=(--agent "$tomlkey=$link")
-        pending_keys+=("$tomlkey")
     done
 
-    if [[ ${#pending_keys[@]} -eq 0 ]]; then
+    if [[ ${#agent_args[@]} -eq 0 ]]; then
         debug "agentsview: every agent declined; nothing to resync"
         return 0
     fi
 
-    # --check compares parsed values: 0 = clean, 1 = a mirror path is missing,
-    # 3 = config error (e.g. a scalar where an array belongs).
-    local check_out check_status
-    set +e
-    check_out="$(/usr/bin/python3 "$script" \
+    # --check compares parsed values: 0 = clean, 1 = a mirror path is missing
+    # (it prints the missing keys, one per line), 3 = config error. Run it in a
+    # conditional context (`if !`) so the expected exit 1 does not trip the
+    # script's ERR trap (set +e wouldn't suppress the trap, only errexit), and
+    # does not leak errexit state into the caller.
+    local check_out missing_keys=()
+    if ! check_out="$(/usr/bin/python3 "$script" \
         --config-path "$AGENTSVIEW_HOST_CONFIG" \
         --home "$HOME" \
         --check \
-        "${agent_args[@]}" 2>&1)"
-    check_status=$?
-    set -e
-    if [[ "$check_status" -eq 3 ]]; then
-        error "agentsview: cannot update $AGENTSVIEW_HOST_CONFIG:"
-        error "$check_out"
-        return 1
-    fi
-    if [[ "$check_status" -ne 1 ]]; then
-        if [[ "$check_status" -ne 0 ]]; then
-            error "agentsview: --check failed (exit $check_status): $check_out"
+        "${agent_args[@]}" 2>&1)"; then
+        # Non-zero. exit 1 = pending (check_out lists the missing keys);
+        # anything else (3 = config error, or an uncaught failure now mapped to
+        # 3 inside the script) is a hard error, not a pending change.
+        if [[ "$?" -ne 1 ]]; then
+            error "agentsview: cannot update $AGENTSVIEW_HOST_CONFIG:"
+            error "$check_out"
             return 1
         fi
+    else
+        # exit 0: nothing missing.
         debug "agentsview: $AGENTSVIEW_HOST_CONFIG already up to date"
         return 0
     fi
 
+    # check_out holds exactly the missing keys (one per line). Record only
+    # those on decline, not every non-declined agent -- declining a single new
+    # agent must not pollute the decline list with agents that were already
+    # present.
+    local key
+    while IFS= read -r key; do
+        [[ -n "$key" ]] && missing_keys+=("$key")
+    done <<< "$check_out"
+    if [[ ${#missing_keys[@]} -eq 0 ]]; then
+        debug "agentsview: $AGENTSVIEW_HOST_CONFIG already up to date"
+        return 0
+    fi
+
+    # Build --agent args for only the missing keys, so the diff and write are
+    # scoped to what's actually changing.
+    local missing_args=() mk
+    for mk in "${missing_keys[@]}"; do
+        for agent in "${AGENTSVIEW_AGENTS[@]}"; do
+            if [[ "$(agentsview_field TOMLKEY "$agent")" == "$mk" ]]; then
+                missing_args+=(--agent "$mk=$SV_PRIVATE_DIR/sessions/$agent")
+                break
+            fi
+        done
+    done
+
     # Pending changes. Non-interactive: don't write, don't hang on read, and
     # don't record a decline (the user never saw the prompt).
     if [[ ! -t 0 ]]; then
-        trace "agentsview: config changes pending but non-interactive; skipping"
+        trace "agentsview: config changes pending (${missing_keys[*]}) but non-interactive; skipping"
         return 0
     fi
 
@@ -210,7 +233,7 @@ agentsview_resync_config() {
         --config-path "$AGENTSVIEW_HOST_CONFIG" \
         --home "$HOME" \
         --diff \
-        "${agent_args[@]}" 2>&1)"; then
+        "${missing_args[@]}" 2>&1)"; then
         error "agentsview: failed to compute config diff:"
         error "$diff_out"
         return 1
@@ -229,8 +252,8 @@ agentsview_resync_config() {
     local reply
     read -r reply
     if [[ "$reply" != "y" && "$reply" != "Y" ]]; then
-        info "agentsview: declined; recording ${pending_keys[*]} as permanently skipped"
-        agentsview_record_decline "${pending_keys[@]}"
+        info "agentsview: declined; recording ${missing_keys[*]} as permanently skipped"
+        agentsview_record_decline "${missing_keys[@]}"
         return 0
     fi
 
@@ -238,7 +261,7 @@ agentsview_resync_config() {
         --config-path "$AGENTSVIEW_HOST_CONFIG" \
         --home "$HOME" \
         --write \
-        "${agent_args[@]}"; then
+        "${missing_args[@]}"; then
         error "agentsview: failed to write $AGENTSVIEW_HOST_CONFIG"
         return 1
     fi

--- a/sv-agentsview-setup
+++ b/sv-agentsview-setup
@@ -227,7 +227,7 @@ agentsview_resync_config() {
             ;;  # pending -- fall through (check_err kept for the empty-keys
               #      error if --check produced no keys)
         *)
-            error "agentsview: cannot update $AGENTSVIEW_HOST_CONFIG:"
+            error "agentsview: cannot update $AGENTSVIEW_HOST_CONFIG"
             [[ -n "$check_err_text" ]] && error "$check_err_text"
             rm -f "$check_err"
             return 1
@@ -284,8 +284,10 @@ agentsview_resync_config() {
         --home "$HOME" \
         --diff \
         "${missing_args[@]}" 2>"$diff_err" )"; then
-        error "agentsview: failed to compute config diff:"
-        error "$(cat "$diff_err" 2>/dev/null)"
+        local diff_err_text
+        diff_err_text=$( trap - ERR; cat "$diff_err" 2>/dev/null ) || true
+        error "agentsview: failed to compute config diff"
+        [[ -n "$diff_err_text" ]] && error "$diff_err_text"
         rm -f "$diff_err"
         return 1
     fi

--- a/sv-agentsview-setup
+++ b/sv-agentsview-setup
@@ -175,26 +175,36 @@ agentsview_resync_config() {
     # (it prints the missing keys, one per line), 3 = config error. Run it in a
     # conditional context (`if !`) so the expected exit 1 does not trip the
     # script's ERR trap (set +e wouldn't suppress the trap, only errexit), and
-    # does not leak errexit state into the caller.
-    local check_out missing_keys=()
-    if ! check_out="$(/usr/bin/python3 "$script" \
+    # does not leak errexit state into the caller. Use the `cmd && st=0 || st=$?`
+    # idiom: it runs in a conditional context (so the ERR trap is suppressed
+    # for the command and errexit does not abort), and the `||` branch sees
+    # the command's original exit status. (`if ! cmd` would invert $? to 0;
+    # `if cmd; then...fi` with no else resets $? to 0 after the fi.)
+    local check_out check_status missing_keys=()
+    # Clear the inherited ERR trap inside the subshell (set -E propagates it
+    # into $(...), where it fires independently of the outer conditional
+    # context and prints a misleading "exitcode 1" on the expected pending).
+    check_out="$( trap - ERR; /usr/bin/python3 "$script" \
         --config-path "$AGENTSVIEW_HOST_CONFIG" \
         --home "$HOME" \
         --check \
-        "${agent_args[@]}" 2>&1)"; then
-        # Non-zero. exit 1 = pending (check_out lists the missing keys);
-        # anything else (3 = config error, or an uncaught failure now mapped to
-        # 3 inside the script) is a hard error, not a pending change.
-        if [[ "$?" -ne 1 ]]; then
+        "${agent_args[@]}" 2>&1)" && check_status=0 || check_status=$?
+    # exit 0 = nothing missing; exit 1 = pending (check_out lists the missing
+       # keys); anything else (3 = config error, or an uncaught failure now
+    # mapped to 3 inside the script) is a hard error, not a pending change.
+    case "$check_status" in
+        0)
+            debug "agentsview: $AGENTSVIEW_HOST_CONFIG already up to date"
+            return 0
+            ;;
+        1)
+            ;;  # pending -- fall through
+        *)
             error "agentsview: cannot update $AGENTSVIEW_HOST_CONFIG:"
             error "$check_out"
             return 1
-        fi
-    else
-        # exit 0: nothing missing.
-        debug "agentsview: $AGENTSVIEW_HOST_CONFIG already up to date"
-        return 0
-    fi
+            ;;
+    esac
 
     # check_out holds exactly the missing keys (one per line). Record only
     # those on decline, not every non-declined agent -- declining a single new

--- a/sv-agentsview-setup
+++ b/sv-agentsview-setup
@@ -125,13 +125,23 @@ agentsview_declined_keys() {
 }
 
 # Record TOML keys (args) as permanently declined, de-duplicated against the
-# existing list. Idempotent.
+# existing list. Idempotent. Only records keys that map to a known agent
+# (a belt-and-braces guard so a stray stderr line captured into the
+# missing-keys stream can never be written to this user-facing file).
 agentsview_record_decline() {
     mkdir -p "$SV_PRIVATE_DIR/setup"
-    local existing key
+    local existing key known agent
     existing="$(agentsview_declined_keys)"
     for key in "$@"; do
         [[ -n "$key" ]] || continue
+        known=0
+        for agent in "${AGENTSVIEW_AGENTS[@]}"; do
+            if [[ "$(agentsview_field TOMLKEY "$agent")" == "$key" ]]; then
+                known=1
+                break
+            fi
+        done
+        [[ "$known" -eq 1 ]] || continue
         if printf '%s\n' "$existing" | grep -Fxq -- "$key"; then
             continue
         fi
@@ -172,36 +182,42 @@ agentsview_resync_config() {
     fi
 
     # --check compares parsed values: 0 = clean, 1 = a mirror path is missing
-    # (it prints the missing keys, one per line), 3 = config error. Run it in a
-    # conditional context (`if !`) so the expected exit 1 does not trip the
-    # script's ERR trap (set +e wouldn't suppress the trap, only errexit), and
-    # does not leak errexit state into the caller. Use the `cmd && st=0 || st=$?`
-    # idiom: it runs in a conditional context (so the ERR trap is suppressed
-    # for the command and errexit does not abort), and the `||` branch sees
-    # the command's original exit status. (`if ! cmd` would invert $? to 0;
-    # `if cmd; then...fi` with no else resets $? to 0 after the fi.)
-    local check_out check_status missing_keys=()
-    # Clear the inherited ERR trap inside the subshell (set -E propagates it
-    # into $(...), where it fires independently of the outer conditional
-    # context and prints a misleading "exitcode 1" on the expected pending).
+    # (it prints the missing keys to stdout, one per line), 3 = config error
+    # (message on stderr). Capture stdout and stderr separately: stdout is
+    # parsed line-by-line as TOML keys, so any stderr line (a warning, or an
+    # unexpected message) must not become a pseudo-key and must not be written
+    # to the user-facing decline file.
+    #
+    # Use the `cmd && st=0 || st=$?` idiom: it runs in a conditional context
+    # (ERR trap suppressed for the command, errexit does not abort) and the
+    # `||` branch sees the command's original exit status. (`if ! cmd` would
+    # invert $? to 0; `if cmd; then...fi` with no else resets $? to 0 after
+    # the fi.) Clear the inherited ERR trap inside the $(...) subshell too --
+    # set -E propagates it into the subshell where it fires independently of
+    # the outer conditional context.
+    local check_out check_err check_status missing_keys=()
+    check_err=$(mktemp)
     check_out="$( trap - ERR; /usr/bin/python3 "$script" \
         --config-path "$AGENTSVIEW_HOST_CONFIG" \
         --home "$HOME" \
         --check \
-        "${agent_args[@]}" 2>&1)" && check_status=0 || check_status=$?
-    # exit 0 = nothing missing; exit 1 = pending (check_out lists the missing
-       # keys); anything else (3 = config error, or an uncaught failure now
+        "${agent_args[@]}" 2>"$check_err" )" && check_status=0 || check_status=$?
+    # exit 0 = nothing missing; exit 1 = pending (stdout lists the missing
+    # keys); anything else (3 = config error, or an uncaught failure now
     # mapped to 3 inside the script) is a hard error, not a pending change.
     case "$check_status" in
         0)
+            rm -f "$check_err"
             debug "agentsview: $AGENTSVIEW_HOST_CONFIG already up to date"
             return 0
             ;;
         1)
+            rm -f "$check_err"
             ;;  # pending -- fall through
         *)
             error "agentsview: cannot update $AGENTSVIEW_HOST_CONFIG:"
-            error "$check_out"
+            error "$(cat "$check_err" 2>/dev/null)"
+            rm -f "$check_err"
             return 1
             ;;
     esac
@@ -239,7 +255,7 @@ agentsview_resync_config() {
     fi
 
     local diff_out
-    if ! diff_out="$(/usr/bin/python3 "$script" \
+    if ! diff_out="$( trap - ERR; /usr/bin/python3 "$script" \
         --config-path "$AGENTSVIEW_HOST_CONFIG" \
         --home "$HOME" \
         --diff \

--- a/sv-agentsview-setup
+++ b/sv-agentsview-setup
@@ -163,7 +163,7 @@ agentsview_resync_config() {
     # user-invoked setup script.
     local script="${AGENTSVIEW_CONFIG_SCRIPT:-$WORKSPACE/helpers/agentsview-config.py}"
     if [[ ! -f "$script" ]]; then
-        trace "agentsview: helpers/agentsview-config.py not installed; skipping config resync"
+        trace "agentsview: $script not installed; skipping config resync"
         return 0
     fi
 
@@ -207,6 +207,10 @@ agentsview_resync_config() {
         --home "$HOME" \
         --check \
         "${agent_args[@]}" 2>"$check_err" )" && check_status=0 || check_status=$?
+    # Read the stderr once, trap cleared so a failing cat does not leak the
+    # inherited ERR trap into the diagnostic.
+    local check_err_text
+    check_err_text=$( trap - ERR; cat "$check_err" 2>/dev/null ) || true
     # exit 0 = nothing missing; exit 1 = pending (stdout lists the missing
     # keys); anything else (3 = config error, or an uncaught failure now
     # mapped to 3 inside the script) is a hard error, not a pending change.
@@ -224,7 +228,7 @@ agentsview_resync_config() {
               #      error if --check produced no keys)
         *)
             error "agentsview: cannot update $AGENTSVIEW_HOST_CONFIG:"
-            error "$(cat "$check_err" 2>/dev/null)"
+            [[ -n "$check_err_text" ]] && error "$check_err_text"
             rm -f "$check_err"
             return 1
             ;;
@@ -242,10 +246,10 @@ agentsview_resync_config() {
         # We only reach here on check_status==1 (the 0 case returned above). An
         # exit 1 with no keys is a protocol violation -- e.g. an import-time
         # error in the vendored tomli shim exiting 1 with empty stdout and a
-        # traceback on stderr -- not a clean config. Surface the stderr so the
-        # user can diagnose it; do not silently treat it as up to date.
+        # traceback on stderr -- not a clean config. Surface the stderr (if any)
+        # so the user can diagnose it; do not silently treat it as up to date.
         error "agentsview: --check reported pending but listed no keys; cannot update $AGENTSVIEW_HOST_CONFIG"
-        error "$(cat "$check_err" 2>/dev/null)"
+        [[ -n "$check_err_text" ]] && error "$check_err_text"
         rm -f "$check_err"
         return 1
     fi


### PR DESCRIPTION
Closes #194. This is a proposal for the decline-state shape I wanted to check
with you. Happy to revise it if you prefer a different approach.

## The problem

`sv-agentsview-setup` recorded the opt-in choice once. Then it returned early
on every run after that. The generated setup-merge script tracks
`AGENTSVIEW_AGENTS`. So a user who already opted in got `~/.pi/agent/sessions`
created and ACLed every session. But the mirror symlink and the `pi_dirs` key
in `~/.agentsview/config.toml` were written once, at opt-in. They were never
written again. So `pi` sessions never showed up in agentsview. Nothing
errored. The only fix was to delete the state file and run the opt-in again.

`pi` was the first agent added since this flow shipped. Every agent from here
on had the same problem. #182 made the gap visible. This PR proposes a fix.

## The change

`sv-agentsview-setup` re-syncs on every run once you enable it. It installs the
mirror symlinks for every agent. It adds any scan path that is missing to
`~/.agentsview/config.toml`. The first time a path is missing, it shows a diff
and asks for confirmation. New agents that sandvault adds later appear the
next time you run the command.

Three things had to land first, or the re-sync is a regression. All three are
in this PR.

### 1. A scalar value was character-split

`apply_agents` did `existing = list(result[key])` with no list check. A
hand-written scalar like `claude_project_dirs = "/some/path"` parses as TOML.
Then `list()` character-split it into `['/', 's', 'o', ...]`. This was a
silent, destructive rewrite.

Now a non-list value for a managed key is rejected with a clear error. The
script exits 3, the same code it uses for a parse failure.

### 2. There was no way to decline permanently

`agentsview_update_config` returned 0 on both accept and decline. The return
code did not distinguish "declined" from "nothing to do." So a user who
declined a new agent got re-prompted on every run.

Now declining records the pending keys to a per-key decline list. The file is
`$SV_PRIVATE_DIR/setup/agentsview-declined.keys`, one agentsview TOML key per
line. Declined agents are filtered out of the re-sync. They are never
re-prompted. A new agent added later is not in the list, so it still prompts.

I chose a separate skip-list file, not a change to the opt-in state file. The
existing `enabled`/`disabled` state keeps its meaning. The skip list is a
separate concern. Remove the line to enable an agent again.

The symlink and the ACL are still installed for declined agents. They are
harmless without the scan path.

### 3. The diff was on rendered text, not parsed values

The writer round-trips through `tomllib` and `tomli_w`. It drops comments and
normalizes formatting. So a hand-edited `config.toml` produced a non-empty diff
forever. That meant a prompt on every run, even when nothing was missing.

A new `--check` mode compares `apply_agents(config) == config` on parsed
values. It exits 0 when the merge is a no-op. It exits 1 when a mirror path is
missing. The shell gates the prompt on `--check`. So comment and formatting
drift no longer re-prompts. `--diff` is only shown when `--check` says
something is missing.

## Decline-state shape

This is the part I wanted to check with you first. I went with a per-key skip
list in a separate file. This was the second of the two shapes the issue
offered. I can change it if you prefer the marker-in-the-state-file shape.

- The opt-in state file is unchanged. It still holds `enabled` or `disabled`.
  Existing installs keep working.
- The decline list is a new file. It holds the TOML keys the user declined.
  It is easy to inspect and clear. Remove a line to re-prompt for that agent.

## Verification

- `helpers/agentsview-config.py --self-test` runs 10 tests (was 6). They cover
  scalar rejection, the parsed `--check` equality, and the malformed-config
  exit code.
- `scripts/tests` has a `--check` exit-code test, a structural wiring test, and
  the integration test wired in.
- `scripts/test-agentsview-resync.sh` sources the real `sv-agentsview-setup`
  functions and drives the real python writer. It runs 10 end-to-end cases.
  They cover the no-op, the check-to-write-to-check idempotence, the decline
  de-dup, the scalar error, the partial-decline filter, the pending skip
  path, and the empty-keys protocol violation.
- shellcheck is clean. The bash parses on system bash 3.2.

I branched off `upstream/main`, not the stale `main` on the fork. The `main`
branch on the fork is behind upstream. It carries a squashed copy of the pi
work. PR #182 is
merged upstream, so this builds on the same base you reviewed.

## Review

I ran a roborev refine-and-polish loop with three reviewers (codex, pi,
claude-code). It ran 7 iterations and converged. The High and Medium findings
closed at iteration 5. One Low remains, on the pushback list. The `--diff`
failure path is a copy of the tested `--check` path, so it has no dedicated
test. Closing it needs a pty harness or a force-interactive seam in the
script. Both feel disproportionate to a Low, but I can add the test if you
want it. The loop is documented in the private notes, not linked here.

The prose in this body, the README, and the CHANGELOG was rewritten in
Simplified Technical English.
