### PR TITLE
Add authorized_keys.d for extra SSH keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable user-facing changes to SandVault are documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- Extra SSH public keys can now reach the sandvault user: drop one key per file into `~/.config/codeofhonor/sandvault/authorized_keys.d/` and run `sv build`. The sandvault user's `authorized_keys` is regenerated from that directory on every run, so deleting a file revokes the key. Files that are not public keys are ignored with a warning, and a private key left there stops the build instead of being copied into the sandbox.
+
 ## [1.28.0] - 2026-08-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -114,6 +114,15 @@ The default mode for sandvault runs commands as a limited user (basically `sudo 
   sv --ssh gemini
 ```
 
+To let other keys SSH into the sandvault user, drop each public key into its own file in `~/.config/codeofhonor/sandvault/authorized_keys.d/`, then run any `sv` command to apply it:
+
+```bash
+cp ~/.ssh/id_ed25519_laptop.pub ~/.config/codeofhonor/sandvault/authorized_keys.d/laptop
+sv build
+```
+
+Those files are the source of truth: sandvault regenerates the sandvault user's `authorized_keys` from them plus its own key on every run, so deleting a file revokes that key on the next run. Files that are not SSH public keys are ignored with a warning, and a private key left there stops the build rather than being copied into the sandbox.
+
 
 ## Advanced Commands
 

--- a/scripts/tests
+++ b/scripts/tests
@@ -783,6 +783,132 @@ EOF
     }
     queue_test test_fix_permissions_rejects_non_build
 
+    # Extra public keys dropped into AUTHORIZED_KEYS_DIR are written into the
+    # generated authorized_keys, and removing one revokes it. Run
+    # configure_ssh_access in isolation so the test never touches the real
+    # sandvault install.
+    test_authorized_keys_dir() {
+        local workdir keys_dir generated expected got output
+        workdir="$(mktemp -d)"
+        keys_dir="$workdir/authorized_keys.d"
+        generated="$workdir/guest/home/.ssh/authorized_keys"
+        mkdir -p "$keys_dir"
+        ssh-keygen -t ed25519 -f "$workdir/id" -N "" -q -C "sandvault"
+        ssh-keygen -t ed25519 -f "$workdir/extra" -N "" -q -C "extra@laptop"
+        # No trailing newline: the generated file must still split the keys.
+        printf '%s' "$(cat "$workdir/extra.pub")" > "$keys_dir/extra"
+
+        {
+            echo '#!/bin/bash'
+            echo 'set -Eeuo pipefail'
+            echo 'trace() { :; }'
+            echo 'warn() { echo >&2 "$*"; }'
+            echo 'abort() { echo >&2 "$*"; exit 1; }'
+            sed -n '/^configure_ssh_access() {$/,/^}$/p' "$SV_BASE"
+            echo 'configure_ssh_access'
+        } > "$workdir/run"
+        chmod +x "$workdir/run"
+
+        run_configure_ssh_access() {
+            NO_BUILD=false \
+                WORKSPACE="$workdir" \
+                AUTHORIZED_KEYS_DIR="$keys_dir" \
+                SSH_KEYFILE_PRIV="$workdir/id" \
+                SSH_KEYFILE_PUB="$workdir/id.pub" \
+                SANDVAULT_USER="sandvault-test" \
+                "$workdir/run"
+        }
+
+        set +e
+        output="$(run_configure_ssh_access 2>&1)"
+        set -e
+        got="$output$(cat "$generated" 2>/dev/null)"
+        expected="$(cat "$workdir/extra.pub" "$workdir/id.pub")"
+        if [[ "$got" != "$expected" ]]; then
+            fail "authorized_keys.d keys are installed and revoked" "$expected" "$got"
+            rm -rf "$workdir"
+            return
+        fi
+
+        rm -f "$keys_dir/extra"
+        set +e
+        output="$(run_configure_ssh_access 2>&1)"
+        set -e
+        got="$output$(cat "$generated" 2>/dev/null)"
+        expected="$(cat "$workdir/id.pub")"
+        if [[ "$got" == "$expected" ]]; then
+            pass "authorized_keys.d keys are installed and revoked"
+        else
+            fail "authorized_keys.d keys are installed and revoked" "$expected" "$got"
+        fi
+        rm -rf "$workdir"
+    }
+    queue_test test_authorized_keys_dir
+
+    # A file that is not a public key is skipped with a warning; a private key
+    # aborts, because copying one in would hand it to the sandvault user.
+    test_authorized_keys_dir_rejects_non_public_keys() {
+        local workdir keys_dir generated expected got output status
+        workdir="$(mktemp -d)"
+        keys_dir="$workdir/authorized_keys.d"
+        generated="$workdir/guest/home/.ssh/authorized_keys"
+        mkdir -p "$keys_dir"
+        ssh-keygen -t ed25519 -f "$workdir/id" -N "" -q -C "sandvault"
+        printf 'notes about my keys\n' > "$keys_dir/README"
+
+        {
+            echo '#!/bin/bash'
+            echo 'set -Eeuo pipefail'
+            echo 'trace() { :; }'
+            echo 'warn() { echo >&2 "$*"; }'
+            echo 'abort() { echo >&2 "$*"; exit 1; }'
+            sed -n '/^configure_ssh_access() {$/,/^}$/p' "$SV_BASE"
+            echo 'configure_ssh_access'
+        } > "$workdir/run"
+        chmod +x "$workdir/run"
+
+        run_configure_ssh_access() {
+            NO_BUILD=false \
+                WORKSPACE="$workdir" \
+                AUTHORIZED_KEYS_DIR="$keys_dir" \
+                SSH_KEYFILE_PRIV="$workdir/id" \
+                SSH_KEYFILE_PUB="$workdir/id.pub" \
+                SANDVAULT_USER="sandvault-test" \
+                "$workdir/run"
+        }
+
+        set +e
+        output="$(run_configure_ssh_access 2>&1)"
+        set -e
+        expected="Ignoring $keys_dir/README: not an SSH public key"
+        if [[ "$output" != "$expected" ]]; then
+            fail "authorized_keys.d rejects non-public-key files" "$expected" "$output"
+            rm -rf "$workdir"
+            return
+        fi
+        got="$(cat "$generated" 2>/dev/null)"
+        expected="$(cat "$workdir/id.pub")"
+        if [[ "$got" != "$expected" ]]; then
+            fail "authorized_keys.d rejects non-public-key files" "$expected" "$got"
+            rm -rf "$workdir"
+            return
+        fi
+
+        cp "$workdir/id" "$keys_dir/oops"
+        set +e
+        output="$(run_configure_ssh_access 2>&1)"
+        status=$?
+        set -e
+        if [[ "$status" -ne 0 && "$output" == *"is a private key"* ]]; then
+            pass "authorized_keys.d rejects non-public-key files"
+        else
+            fail "authorized_keys.d rejects non-public-key files" \
+                "non-zero exit with private key message" "$status | $output"
+        fi
+        rm -rf "$workdir"
+    }
+    queue_test test_authorized_keys_dir_rejects_non_public_keys
+
     # Test that /var/sandvault/ is world-traversable
     test_var_sandvault_traversable() {
         local perms

--- a/sv
+++ b/sv
@@ -70,8 +70,7 @@ git_config_require_value() {
 
 configure_ssh_access() {
     local guest_authorized_keys
-    local ssh_public_key
-    local ssh_key_count
+    local key_file
     local tmp_authorized_keys
 
     if [[ ! -f "$SSH_KEYFILE_PRIV" || ! -f "$SSH_KEYFILE_PUB" ]]; then
@@ -88,24 +87,45 @@ configure_ssh_access() {
             -C "${HOST_USER}-to-sandvault@${SSH_HOST}"
     fi
 
-    # Add HOST_USER SSH public key to SANDVAULT_USER authorized_keys
+    # Generate SANDVAULT_USER authorized_keys: every file in AUTHORIZED_KEYS_DIR
+    # followed by the HOST_USER SSH public key. The file is written in full each
+    # run, so deleting a file from AUTHORIZED_KEYS_DIR revokes that key.
     guest_authorized_keys="$WORKSPACE/guest/home/.ssh/authorized_keys"
-    ssh_public_key="$(<"$SSH_KEYFILE_PUB")"
-    ssh_key_count="$(grep -Fxc "$ssh_public_key" "$guest_authorized_keys" 2>/dev/null || true)"
-    if [[ "$ssh_key_count" -ne 1 ]]; then
-        if [[ "$NO_BUILD" == "true" ]]; then
-            abort "$SANDVAULT_USER authorized_keys would change but --no-build flag is set"
+    mkdir -p "$AUTHORIZED_KEYS_DIR"
+    tmp_authorized_keys="$(mktemp)"
+    for key_file in "$AUTHORIZED_KEYS_DIR"/*; do
+        [[ -f "$key_file" ]] || continue
+        # "ssh-keygen -l" reports the public half of a private key too, so check
+        # for that separately: copying one into the guest would hand the
+        # untrusted sandvault user a private key.
+        if grep -q "PRIVATE KEY" "$key_file"; then
+            rm -f "$tmp_authorized_keys"
+            abort "$key_file is a private key: $AUTHORIZED_KEYS_DIR holds public keys only"
         fi
-        trace "Configuring remote SSH access"
-        mkdir -p "$(dirname "$guest_authorized_keys")"
-        /bin/chmod 0700 "$(dirname "$guest_authorized_keys")"
-        touch "$guest_authorized_keys"
-        tmp_authorized_keys="$(mktemp)"
-        grep -Fvx "$ssh_public_key" "$guest_authorized_keys" > "$tmp_authorized_keys" || true
-        printf '%s\n' "$ssh_public_key" >> "$tmp_authorized_keys"
-        /bin/chmod 0600 "$tmp_authorized_keys"
-        mv -f "$tmp_authorized_keys" "$guest_authorized_keys"
+        if ! ssh-keygen -l -f "$key_file" &>/dev/null; then
+            warn "Ignoring $key_file: not an SSH public key"
+            continue
+        fi
+        # "awk 1" copies the file, supplying the trailing newline it may lack so
+        # that two keys never end up concatenated onto the same line.
+        awk 1 "$key_file" >> "$tmp_authorized_keys"
+    done
+    awk 1 "$SSH_KEYFILE_PUB" >> "$tmp_authorized_keys"
+
+    if cmp -s "$tmp_authorized_keys" "$guest_authorized_keys"; then
+        rm -f "$tmp_authorized_keys"
+        return 0
     fi
+    if [[ "$NO_BUILD" == "true" ]]; then
+        rm -f "$tmp_authorized_keys"
+        abort "$SANDVAULT_USER authorized_keys would change but --no-build flag is set"
+    fi
+
+    trace "Configuring remote SSH access"
+    mkdir -p "$(dirname "$guest_authorized_keys")"
+    /bin/chmod 0700 "$(dirname "$guest_authorized_keys")"
+    /bin/chmod 0600 "$tmp_authorized_keys"
+    mv -f "$tmp_authorized_keys" "$guest_authorized_keys"
 }
 
 
@@ -211,6 +231,11 @@ IOS_SIM_UDID=""
 readonly SSH_DIR="$HOME/.ssh"
 readonly SSH_KEYFILE_PRIV="$SSH_DIR/id_ed25519_sandvault"
 readonly SSH_KEYFILE_PUB="$SSH_KEYFILE_PRIV.pub"
+
+# Additional public keys allowed to SSH into the sandvault user, one key per
+# file. Kept in the host user's config directory so it survives upgrades and so
+# the (untrusted) sandvault user cannot grant itself extra access.
+readonly AUTHORIZED_KEYS_DIR="$INSTALL_PRODUCT/authorized_keys.d"
 
 # Sandbox profile to restrict /Volumes access (external drives)
 # Stored in /var/sandvault/ so sandvault user cannot modify it


### PR DESCRIPTION
- allow other machines to reach the sandvault user without hand editing a generated file that upgrades overwrite
- keep the directory in the host user's config so the untrusted sandvault user cannot grant itself SSH access
- regenerate `authorized_keys` in full each run so deleting a file revokes that key
- reject private keys outright: `ssh-keygen -l` reports their public half, so one would be copied into the sandbox unnoticed