### PR TITLE
fix(ios): add iosef timeout and wall-clock bounded describe polling

### DIFF
--- a/helpers/sv-ios-bridge
+++ b/helpers/sv-ios-bridge
@@ -39,6 +39,15 @@ from urllib.parse import parse_qs, urlparse
 # because cold runtimes routinely take longer than this.
 SUBPROCESS_TIMEOUT_SEC = 120
 
+# iosef UI-automation calls (describe/tap/type/swipe/view) get a tighter budget
+# than the 120s default. These are interactive queries against an already-booted
+# simulator: they normally return in under a second, and when they don't it is
+# because iosef is wedged attaching to the device rather than making progress.
+# At the 120s default a single hung call outlives its caller's whole retry loop,
+# so the retry never happens and the failure looks like an empty response. A
+# short budget converts that hang into a fast, visible, retryable error.
+IOSEF_TIMEOUT_SEC = 20
+
 # `simctl bootstatus -b` blocks server-side until the simulator finishes
 # booting. Cold first-boot of a freshly installed iOS runtime can exceed the
 # normal 120s budget, so give it its own (much larger) timeout. If even this
@@ -283,7 +292,7 @@ class Handler(BaseHTTPRequestHandler):
         except RuntimeError as e:
             self._send_error(500, str(e))
             return
-        rc, stdout, stderr = run_argv(argv)
+        rc, stdout, stderr = run_argv(argv, timeout=IOSEF_TIMEOUT_SEC)
         self._send_shell_result(rc, stdout, stderr)
 
     def _simctl(self, *args):
@@ -393,7 +402,7 @@ class Handler(BaseHTTPRequestHandler):
             argv = iosef_cmd() + ["view", "--local", "--device", UDID]
         except RuntimeError as e:
             return self._send_error(500, str(e))
-        rc, stdout, stderr = run_argv(argv)
+        rc, stdout, stderr = run_argv(argv, timeout=IOSEF_TIMEOUT_SEC)
         if rc != 0 or not stdout:
             return self._send_error(
                 500, "iosef view failed",

--- a/tests/ios-simulator/scripts/tests
+++ b/tests/ios-simulator/scripts/tests
@@ -101,15 +101,26 @@ phase_launch_preferences() {
 phase_describe() {
     log "Test 3: describe"
     local response=""
-    local i
-    for i in $(seq 1 15); do
-        response=$(curl -sf "$EP/describe") || response=""
+    local i=0
+    local deadline=$(( $(date +%s) + 90 ))
+    # Bound by wall-clock, not poll count: a slow/wedged iosef makes each call
+    # take seconds rather than returning instantly, so a fixed poll count can
+    # stretch this phase to many minutes. The deadline keeps the phase bounded
+    # however long individual calls take.
+    while :; do
+        i=$(( i + 1 ))
+        # No `-f`: on an HTTP error curl would print nothing, discarding the
+        # bridge's error body (e.g. iosef's "timeout after Ns"). The length
+        # check below still rejects error responses, so keeping the body only
+        # affects what a failure reports, not whether it passes.
+        response=$(curl -s "$EP/describe") || response=""
         if [[ ${#response} -gt 100 ]]; then
             log "  PASS (${#response} bytes, after ${i} polls)"
             return
         fi
-        if [[ $i -eq 15 ]]; then
-            fail "/describe returned unexpected output:\n${response}"
+        if [[ $(date +%s) -ge $deadline ]]; then
+            fail "/describe did not return a tree within 90s (${i} polls); last response:\n${response}"
+            return
         fi
         sleep 2
     done


### PR DESCRIPTION
## Summary
- Add a 20s timeout for iosef UI-automation calls (describe/tap/type/swipe/view) instead of the default 120s, so a wedged iosef produces a fast retryable error instead of silently outliving the caller's retry loop
- Switch the describe test phase from a fixed 15-poll count to a 90s wall-clock deadline, preventing slow iosef calls from stretching the phase to many minutes

## Test plan
- [ ] Run ios-simulator tests to verify describe polling completes within the deadline
- [ ] Confirm iosef timeout errors surface correctly when iosef is unresponsive