### PR TITLE
fix: stop `sv -N opencode` looping and falsely reporting "not installed"

### DIFF
--- a/guest/home/bin/opencode
+++ b/guest/home/bin/opencode
@@ -2,16 +2,64 @@
 set -Eeuo pipefail
 trap 'echo >&2 "${BASH_SOURCE[0]}: line $LINENO: $BASH_COMMAND: exitcode $?"' ERR
 
+WRAPPER_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+
+# Re-entry guard, independent of how PATH is spelled. The PATH filter below is
+# the first defence against the #235 recursion, but it matches entries exactly,
+# so a user .zprofile prepending "$HOME/bin/" (trailing slash) slips past it.
+# check_version() already treats a non-zero probe as "no version installed".
+if [[ -n "${SV_OPENCODE_INSTALLING:-}" ]]; then
+    echo >&2 "opencode: refusing to re-enter the installer (webcoyote/sandvault#235)"
+    exit 1
+fi
+
 # shellcheck source=sv-tool-prompts.sh
-source "$(dirname "${BASH_SOURCE[0]}")/sv-tool-prompts.sh"
+source "$WRAPPER_DIR/sv-tool-prompts.sh"
 
 unset OPENCODE
 if [[ "${SV_NATIVE_INSTALL:-}" == "true" ]]; then
-    if [[ ! -x "$HOME/.local/bin/opencode" ]]; then
-        echo >&2 "Installing OpenCode natively..."
-        curl -fsSL https://opencode.ai/install | XDG_BIN_DIR="$HOME/.local/bin" bash
+    # Look where the installer actually puts the binary. It assigns
+    # INSTALL_DIR=$HOME/.opencode/bin outright -- not a ${INSTALL_DIR:-...}
+    # default -- and reads no XDG_BIN_DIR at all, so neither variable can move
+    # it. Pointing this wrapper at ~/.local/bin instead meant the guard below
+    # was never satisfied and the final check reported "not installed" after a
+    # perfectly good install (webcoyote/sandvault#235).
+    OPENCODE_NATIVE="$HOME/.opencode/bin/opencode"
+    if [[ ! -x "$OPENCODE_NATIVE" && -x "$HOME/.local/bin/opencode" ]]; then
+        # Reuse a binary already at the pre-#235 location instead of
+        # downloading a second copy elsewhere. The installer never honoured
+        # XDG_BIN_DIR, so sandvault never actually put one there -- but anyone
+        # who staged one by hand did have a working `sv -N opencode`, because
+        # the guard below saw it and skipped the install. Keep that working.
+        OPENCODE_NATIVE="$HOME/.local/bin/opencode"
     fi
-    OPENCODE="$HOME/.local/bin/opencode"
+    if [[ ! -x "$OPENCODE_NATIVE" ]]; then
+        echo >&2 "Installing OpenCode natively..."
+
+        # Hide this wrapper's directory from the installer. Its check_version()
+        # probes `command -v opencode`, `which opencode` and `opencode
+        # --version`; .zprofile puts $HOME/bin ahead of ~/.local/bin, so all
+        # three resolve to THIS script, which runs the installer, which probes
+        # again. That recursion is the ~60 nested installs of #235. Filtering
+        # the entry out is exact -- .zprofile inserts these paths literally --
+        # and leaves everything the installer needs (curl, tar, unzip) on PATH.
+        INSTALL_PATH=""
+        while IFS= read -r dir; do
+            [[ "$dir" == "$WRAPPER_DIR" || "$dir" == "$HOME/bin" ]] && continue
+            INSTALL_PATH="${INSTALL_PATH:+$INSTALL_PATH:}$dir"
+        done < <(tr ':' '\n' <<< "$PATH")
+
+        # --no-modify-path stops the installer appending "export PATH=..." to
+        # .zshrc/.zshenv: sandvault owns those files and rewrites them from
+        # guest/home on every build, so the edit is both lost and noise.
+        # `if !` keeps a failed install from aborting under `set -e`, so we
+        # reach the "not installed" guidance below instead of a bare trap line.
+        if ! curl -fsSL https://opencode.ai/install \
+            | SV_OPENCODE_INSTALLING=1 PATH="$INSTALL_PATH" bash -s -- --no-modify-path; then
+            echo >&2 "WARNING: the OpenCode installer failed."
+        fi
+    fi
+    OPENCODE="$OPENCODE_NATIVE"
 elif command -v brew &>/dev/null ; then
     HOMEBREW_PREFIX="${HOMEBREW_PREFIX:-"$(brew --prefix)"}"
     if [[ -x "$HOMEBREW_PREFIX/bin/opencode" ]]; then
@@ -20,8 +68,31 @@ elif command -v brew &>/dev/null ; then
     fi
 fi
 
+# Fallback: a pre-existing install at a known location. Covers the installer's
+# own target when this wrapper took the Homebrew branch, and ~/.local/bin,
+# where a user may have staged their own build (or where an earlier sandvault
+# aimed its native install). Explicit paths rather than `command -v opencode`:
+# this wrapper is installed at ~/bin/opencode and $HOME/bin precedes both, so a
+# PATH search would resolve to the wrapper and re-exec it in a loop.
 if [[ -z "${OPENCODE:-}" || ! -x "$OPENCODE" ]]; then
-    echo >&2 "ERROR: opencode is not installed"
+    for candidate in "$HOME/.opencode/bin/opencode" "$HOME/.local/bin/opencode"; do
+        if [[ -x "$candidate" ]]; then
+            OPENCODE="$candidate"
+            break
+        fi
+    done
+fi
+
+if [[ -z "${OPENCODE:-}" || ! -x "$OPENCODE" ]]; then
+    # Suggest only sandbox-home paths, never $SHARED_WORKSPACE/user/{bin,
+    # .local/bin}: .zprofile puts those ahead of $HOME/bin, so an opencode
+    # there shadows this wrapper rather than being found by it. Same reasoning
+    # as the pi wrapper.
+    echo >&2 "ERROR: opencode is not installed."
+    echo >&2 "       To install opencode on the host, run 'brew install anomalyco/tap/opencode'."
+    echo >&2 "       To install opencode in the sandbox, run 'sv -N opencode'."
+    echo >&2 "       To use an install you already have, put it at ~/.opencode/bin/opencode"
+    echo >&2 "       or ~/.local/bin/opencode in the sandbox home. Use 'sv shell' to get there."
     exit 1
 fi
 

--- a/scripts/tests
+++ b/scripts/tests
@@ -368,6 +368,72 @@ run_tests() {
     }
     queue_test test_opencode_wrapper_uses_skip_permissions
 
+    # Regression guard for webcoyote/sandvault#235: `sv -N opencode` ran the
+    # upstream installer ~60 times over and then reported "opencode is not
+    # installed" anyway. Two faults, both re-checked against the installer
+    # (460 lines, fetched 2026-09-03), and both guarded here:
+    #
+    #   1. Line 68 is a bare `INSTALL_DIR=$HOME/.opencode/bin` assignment, and
+    #      XDG_BIN_DIR appears nowhere in the script. The wrapper used to pass
+    #      XDG_BIN_DIR="$HOME/.local/bin" and then look there, so its
+    #      already-installed guard never went false and its final -x check
+    #      always failed.
+    #   2. check_version() (lines 221-235) probes `command -v opencode`,
+    #      `which opencode` and `opencode --version`. .zprofile puts $HOME/bin
+    #      -- where this wrapper lives -- ahead of ~/.local/bin, so each probe
+    #      re-entered the wrapper, which re-ran the installer. Fault 1 meant
+    #      nothing ever stopped it.
+    #
+    # Comments are stripped before matching so the explanatory prose in the
+    # wrapper (which names XDG_BIN_DIR and command -v) cannot pass the test on
+    # its own.
+    test_opencode_wrapper_native_install() {
+        local wrapper="$SCRIPT_DIR/../guest/home/bin/opencode"
+        if [[ ! -x "$wrapper" ]]; then
+            fail "opencode wrapper native-installs to ~/.opencode/bin" \
+                "executable wrapper" "$wrapper"
+            return
+        fi
+        local code
+        code=$(grep -vE '^[[:space:]]*#' "$wrapper" | sed 's/[[:space:]]#.*$//')
+        if grep -F -- 'XDG_BIN_DIR' <<< "$code" &>/dev/null; then
+            fail "opencode wrapper native-installs to ~/.opencode/bin" \
+                "no XDG_BIN_DIR (the installer never reads it)" \
+                "wrapper still sets XDG_BIN_DIR"
+        elif ! grep -F -- '"$HOME/.opencode/bin/opencode"' <<< "$code" &>/dev/null; then
+            fail "opencode wrapper native-installs to ~/.opencode/bin" \
+                'the installer'"'"'s hardcoded $HOME/.opencode/bin target' \
+                "$wrapper"
+        elif ! grep -F -- '--no-modify-path' <<< "$code" &>/dev/null; then
+            # Sandvault owns .zshrc/.zprofile and rewrites them from guest/home
+            # on every build, so an installer PATH edit is both lost and noise.
+            fail "opencode wrapper native-installs to ~/.opencode/bin" \
+                "--no-modify-path so the installer leaves .zshrc alone" \
+                "$wrapper"
+        elif ! grep -F -- '"$HOME/bin"' <<< "$code" &>/dev/null; then
+            fail "opencode wrapper native-installs to ~/.opencode/bin" \
+                'the install PATH filtered so $HOME/bin cannot re-enter this wrapper' \
+                "$wrapper"
+        elif [[ $(grep -c 'SV_OPENCODE_INSTALLING' <<< "$code") -lt 2 ]]; then
+            # The PATH filter compares entries exactly, and .zprofile sources
+            # $SHARED_WORKSPACE/user/.zprofile before building PATH -- a user
+            # config prepending "$HOME/bin/" (trailing slash) slips a second
+            # entry past it and the #235 recursion returns. The sentinel must
+            # be both exported into the installer and checked on entry, hence
+            # two occurrences.
+            fail "opencode wrapper native-installs to ~/.opencode/bin" \
+                "SV_OPENCODE_INSTALLING set for the install and checked on entry" \
+                "$wrapper"
+        elif grep -E 'command -v opencode\b|type -P opencode\b|type -aP opencode\b' <<< "$code" &>/dev/null; then
+            fail "opencode wrapper native-installs to ~/.opencode/bin" \
+                "no PATH search for opencode" \
+                "wrapper resolves opencode via command -v/type -P (would self-resolve and loop)"
+        else
+            pass "opencode wrapper native-installs to ~/.opencode/bin"
+        fi
+    }
+    queue_test test_opencode_wrapper_native_install
+
     test_codex_code_mode_host_warmup_present() {
         if grep -F -- "codex-code-mode-host" "$SV_BASE" &>/dev/null \
             && grep -F -- "Warming up codex-code-mode-host" "$SV_BASE" &>/dev/null \


### PR DESCRIPTION
Fixes #235.

## Root cause

Two faults in `guest/home/bin/opencode`, both required to produce the reported behaviour. Both verified by reading the upstream installer at `https://opencode.ai/install` (460 lines, fetched 2026-09-03).

**1 — `XDG_BIN_DIR` is silently ignored.** The wrapper ran:

```bash
curl -fsSL https://opencode.ai/install | XDG_BIN_DIR="$HOME/.local/bin" bash
```

The installer never reads `XDG_BIN_DIR`. Line 68 is `INSTALL_DIR=$HOME/.opencode/bin` — a bare assignment, not a `${INSTALL_DIR:-...}` default, so exporting `INSTALL_DIR` doesn't help either. The binary landed in `~/.opencode/bin`, so the wrapper's `[[ ! -x "$HOME/.local/bin/opencode" ]]` guard never went false and its final `-x` check printed `ERROR: opencode is not installed` after a genuinely successful install.

**2 — the installer probes back through the wrapper.** `check_version()` (installer lines 221-235) runs `command -v opencode`, `which opencode`, and `opencode --version`. `.zprofile` gives an effective PATH of:

```
$SHARED_WORKSPACE/user/bin -> user/.local/bin -> $HOME/bin -> $HOME/.local/bin
```

The wrapper lives at `$HOME/bin/opencode`, so all three probes resolve to the **wrapper**, which re-runs the installer, which probes again. Fault 1 guaranteed nothing broke the recursion.

Every symptom in #235 maps onto these:

| Reported symptom | Cause |
|---|---|
| `Installing OpenCode natively...` ~60x | Fault 2 recursion |
| "OpenCode appeared to launch ~60 times" | same |
| `Installed version:` cycling | installer line 226, once per re-entry |
| `Failed to fetch version information` | rate-limiting / depth exhaustion |
| reports 1.18.27 installed, then `ERROR: opencode is not installed` | Fault 1 |
| `XDG_BIN_DIR=... bash: exitcode 1` | the wrapper's ERR trap printing `$BASH_COMMAND` when the pipeline finally failed |

## Why this went unreported for ~5 months

The broken code is only reachable via `-N`. The default path is Homebrew (`ensure_brew_tool "anomalyco/tap/opencode"`), and that branch is untouched by both faults.

Even under `-N`, it only fails **from a cold start**. With a binary already at `~/.local/bin/opencode` the guard skips the install and both faults are bypassed — verified: zero installer invocations, clean launch.

## This is not upstream drift

I checked, because "an opencode change broke it" was the natural hypothesis. It doesn't hold:

- `opencode.ai/install` is served verbatim from `anomalyco/opencode:install`. Today's fetch is byte-identical to rev `4018c86` (2026-02-12), the newest of 29 revisions of that file.
- `INSTALL_DIR=$HOME/.opencode/bin` is hardcoded in **all 29 revisions** back to 2025-04-23, with one exception.
- `check_version()` and its PATH probe are present in **all 29 revisions**.
- `XDG_BIN_DIR` was honoured for **4h42m** on 2025-07-18 — added 18:15 UTC in `01e7dc2` ("Added install dir priority & user feedback", PR #1129), reverted 22:58 UTC in `c87a746` ("ci: rollback install script"). That is nine months before 3f475b0.
- `guest/home/.zprofile`'s PATH block and `sv`'s `SV_NATIVE_INSTALL` export are unchanged since 3f475b0.

So both faults date from 3f475b0. Worth noting the short-lived upstream version wouldn't have helped anyway — its priority chain fell through to `INSTALL_DIR="$HOME/bin"`, which would have overwritten this very wrapper.

## The fix

- Target `~/.opencode/bin/opencode`, where the installer actually writes.
- Filter the wrapper's own directory out of the PATH handed to the installer, so `check_version()` cannot re-enter it. This is an exact per-entry comparison rather than a `${PATH//...}` substring substitution, which silently no-ops when the entry is last or spelled differently.
- Back that with an `SV_OPENCODE_INSTALLING` sentinel, exported into the installer and checked on entry. The PATH filter alone is not enough: `.zprofile` sources `$SHARED_WORKSPACE/user/.zprofile` *before* it builds PATH, so a user config prepending `"$HOME/bin/"` with a trailing slash leaves an entry the exact-match filter misses — and the full recursion returns. The sentinel does not depend on how PATH is spelled. `check_version()` already treats a non-zero probe as "no version installed", so refusing costs nothing.
- Guard the install pipeline with `if !` so a failed download doesn't abort under `set -e`. Previously the user got a bare ERR-trap line and exit 22; now it falls through to the "not installed" guidance.
- Pass `--no-modify-path` (an installer flag; there is no env var) so it doesn't append `export PATH=...` to `.zshrc`/`.zshenv` — sandvault rewrites those from `guest/home` on every build, so the edit is both lost and noise.
- Reuse an existing `~/.local/bin/opencode` rather than re-downloading, so setups that worked before keep working.
- Resolve the binary by explicit path, never `command -v` — that would re-resolve to the wrapper. Expanded failure message, matching the pi wrapper.

`~/.opencode/bin` is deliberately **not** added to PATH: keeping it off means typing `opencode` in `sv shell` still reaches this wrapper instead of bypassing `OPENCODE_PERMISSION` and the tool prompt.

## Testing

The install path can't be exercised by the static suite, so I built a harness reproducing the #235 layout — wrapper at `~/bin/opencode`, `$HOME/bin` ahead of `~/.local/bin`, invoked by name, plus a stub installer carrying the real one's hardcoded `INSTALL_DIR` and `check_version` probes.

| Scenario | Before | After |
|---|---|---|
| Cold start | 11 nested installs (harness cap), exit 1 `not installed` | 1 install, `--no-modify-path` passed, exit 0 |
| Warm start (`~/.local/bin` populated) | 0 installs, exit 0 | 0 installs, exit 0 |
| `$HOME/bin/` prepended with a trailing slash | 11 nested installs | 1 install, exit 0 |
| Installer exits non-zero | bare trap line, exit 22 | "not installed" guidance, exit 1 |

`scripts/tests` gains `test_opencode_wrapper_native_install`, guarding all six properties (no `XDG_BIN_DIR`; targets `~/.opencode/bin`; passes `--no-modify-path`; filters `$HOME/bin`; no `command -v` self-resolution; re-entry sentinel present). Each branch was mutation-checked to confirm it fails when the property is broken.

Suite result: **73 passed, 1 failed** — `agentsview resync integration`, which fails identically on a clean tree in this environment because it cannot `mkdir` under `/Users/Shared` from inside the sandbox. Unrelated to this change.

## Related

- #237 — `scripts/tests` deletes its own working tree, found in the same session. Not addressed here.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)