### PR TITLE
Release v1.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable user-facing changes to SandVault are documented in this file.
 
+## [1.31.0] - 2026-09-08
+
+### Added
+
+- Muse Code is now a first-class agent: run it with `sv muse` (shortcut `sv m`), and pass arguments through with `--`. It is installed automatically on first run via the `muse-code` Homebrew cask, or with the upstream installer under `--native-install`. Muse runs with `--yolo`, which disables both its approval prompts and its own nested sandbox, since sandvault already provides the sandbox. Two current limitations: the `agentsview` dashboard does not yet cover muse sessions, and `sv --browser muse` / `sv --ios muse` start the browser and simulator but cannot announce the endpoints to muse — read `SV_BROWSER_ENDPOINT` and `SV_IOS_SIMULATOR_ENDPOINT` from its environment, or mention them in your prompt or `AGENTS.md`. ([#238](https://github.com/webcoyote/sandvault/pull/238)) — thanks @jeffbowen!
+
+### Changed
+
+- The sandbox account can no longer mount or unmount disks, including via `diskutil`, `hdiutil`, network shares (`smb://`), and Finder automation. ([#233](https://github.com/webcoyote/sandvault/pull/233))
+
+### Fixed
+
+- Starting the iOS simulator without full Xcode installed now explains the actual problem and how to fix it, instead of failing with a confusing error or a Python traceback. The Command Line Tools alone do not include `simctl`, so the message points to the Mac App Store and the follow-up `xcode-select -s` step. ([#233](https://github.com/webcoyote/sandvault/pull/233))
+
+### Thanks to 2 contributors!
+
+- [@jeffbowen](https://github.com/jeffbowen)
+- [@webcoyote](https://github.com/webcoyote)
+
 ## [1.30.0] - 2026-08-29
 
 ### Changed

--- a/guest/home/bin/start-lightpanda
+++ b/guest/home/bin/start-lightpanda
@@ -24,6 +24,7 @@ _lp_debug "Starting lightpanda on 127.0.0.1..."
     --host 127.0.0.1 \
     --port 0 \
     --log-level info \
+    --ca-cert /etc/ssl/cert.pem \
     > "$_SV_LP_LOG" 2>&1 &
 _SV_LP_PID=$!
 

--- a/sv
+++ b/sv
@@ -144,7 +144,7 @@ fi
 ###############################################################################
 # Resources
 ###############################################################################
-readonly VERSION="1.30.0"
+readonly VERSION="1.31.0"
 
 # Re-entrancy detection: if SV_SESSION_ID is already set, we're already in sandvault.
 NESTED=false
@@ -1750,15 +1750,27 @@ elif [[ "$REBUILD" == "true" ]]; then
     mkdir -p "$SV_PRIVATE_DIR/setup"
 
     # .gitconfig: seed identity if missing, preserving user overrides
+    # Uses a retry loop because concurrent sandbox sessions may race on the
+    # git config lock file (~/.gitconfig.lock).
     cat > "$SV_PRIVATE_DIR/setup/gitconfig" << SETUP_EOF
 #!/bin/bash
 set -Eeuo pipefail
+_git_config_retry() {
+    local attempt
+    for attempt in 1 2 3 4 5; do
+        if "\$@" 2>/dev/null; then
+            return 0
+        fi
+        sleep 0.\$((RANDOM % 5 + 1))
+    done
+    "\$@"
+}
 if [[ ! -f "\$HOME/.gitconfig" ]]; then
-    git config -f "\$HOME/.gitconfig" user.name "$GIT_USER_NAME"
-    git config -f "\$HOME/.gitconfig" user.email "$GIT_USER_EMAIL"
+    _git_config_retry git config -f "\$HOME/.gitconfig" user.name "$GIT_USER_NAME"
+    _git_config_retry git config -f "\$HOME/.gitconfig" user.email "$GIT_USER_EMAIL"
 fi
 if ! git config -f "\$HOME/.gitconfig" --get-all safe.directory 2>/dev/null | /usr/bin/grep -Fx "$SHARED_WORKSPACE/*" &>/dev/null; then
-    git config -f "\$HOME/.gitconfig" --add safe.directory "$SHARED_WORKSPACE/*"
+    _git_config_retry git config -f "\$HOME/.gitconfig" --add safe.directory "$SHARED_WORKSPACE/*"
 fi
 SETUP_EOF
     chmod +x "$SV_PRIVATE_DIR/setup/gitconfig"


### PR DESCRIPTION
## [1.31.0] - 2026-09-08

### Added

- Muse Code is now a first-class agent: run it with `sv muse` (shortcut `sv m`), and pass arguments through with `--`. It is installed automatically on first run via the `muse-code` Homebrew cask, or with the upstream installer under `--native-install`. Muse runs with `--yolo`, which disables both its approval prompts and its own nested sandbox, since sandvault already provides the sandbox. Two current limitations: the `agentsview` dashboard does not yet cover muse sessions, and `sv --browser muse` / `sv --ios muse` start the browser and simulator but cannot announce the endpoints to muse — read `SV_BROWSER_ENDPOINT` and `SV_IOS_SIMULATOR_ENDPOINT` from its environment, or mention them in your prompt or `AGENTS.md`. ([#238](https://github.com/webcoyote/sandvault/pull/238)) — thanks @jeffbowen!

### Changed

- The sandbox account can no longer mount or unmount disks, including via `diskutil`, `hdiutil`, network shares (`smb://`), and Finder automation. ([#233](https://github.com/webcoyote/sandvault/pull/233))

### Fixed

- Starting the iOS simulator without full Xcode installed now explains the actual problem and how to fix it, instead of failing with a confusing error or a Python traceback. The Command Line Tools alone do not include `simctl`, so the message points to the Mac App Store and the follow-up `xcode-select -s` step. ([#233](https://github.com/webcoyote/sandvault/pull/233))
- Fix LightPanda failing to start in sandbox by passing `--ca-cert /etc/ssl/cert.pem` — the sandbox blocks access to the macOS Security framework trust store, so the PEM bundle is used instead.
- Fix flaky `.gitconfig` lock race when concurrent sandbox sessions run during tests by adding retry logic to the gitconfig setup script.

### Thanks to 2 contributors!

- [@jeffbowen](https://github.com/jeffbowen)
- [@webcoyote](https://github.com/webcoyote)