### PR TITLE
Skip /sv skill symlink install when Claude Code is not present

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -12,3 +12,4 @@ Thanks to the following users for improving SandVault:
 - [@redLocomotive](https://github.com/redLocomotive)
 - [@gamepoet](https://github.com/gamepoet)
 - [@jeffbowen](https://github.com/jeffbowen)
+- [@hobthross](https://github.com/hobthross)

--- a/sv
+++ b/sv
@@ -1884,12 +1884,14 @@ fi
 # won't collide with any other skill named "sv". Use /bin/ln explicitly —
 # GNU coreutils `ln` on PATH (e.g. via Homebrew) has incompatible flag
 # handling that has bitten this project before.
-SV_SKILL_SOURCE="$WORKSPACE/skills/sandvault/sv"
-SV_SKILL_DEST="$HOME/.claude/skills/sandvault-sv"
-if [[ ! -L "$SV_SKILL_DEST" ]]; then
-    mkdir -p "$(dirname "$SV_SKILL_DEST")"
-    /bin/ln -sfn "$SV_SKILL_SOURCE" "$SV_SKILL_DEST"
-    debug "Installed /sv skill symlink at $SV_SKILL_DEST"
+if [[ -d "$HOME/.claude" ]]; then
+    SV_SKILL_SOURCE="$WORKSPACE/skills/sandvault/sv"
+    SV_SKILL_DEST="$HOME/.claude/skills/sandvault-sv"
+    if [[ ! -L "$SV_SKILL_DEST" ]]; then
+        mkdir -p "$(dirname "$SV_SKILL_DEST")"
+        /bin/ln -sfn "$SV_SKILL_SOURCE" "$SV_SKILL_DEST"
+        debug "Installed /sv skill symlink at $SV_SKILL_DEST"
+    fi
 fi
 
 if [[ "$COMMAND" == "build" ]]; then


### PR DESCRIPTION
Guard the skill symlink creation with a check for ~/.claude so we don't create directories or print misleading output on machines without Claude Code installed.

Fixes #234